### PR TITLE
refactor: separate external and transformation dependency validation logic

### DIFF
--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -25,8 +25,6 @@ services:
   redis:
     image: redis:7-alpine
     container_name: cbt-redis
-    ports:
-      - "6379:6379"
     volumes:
       - redis_data:/data
     command: redis-server --appendonly yes


### PR DESCRIPTION
- Introduce ExternalValidator interface for external model validation
- Calculate min of external deps vs max of transformation deps for backfill position
- Remove redis port exposure from docker-compose example
- Add comprehensive tests for mixed dependency scenarios