### PR TITLE
refactor: replace position/lag metrics with unified bounds metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Models can execute external scripts instead of SQL. The script receives environm
 
 Environment variables provided to scripts:
 - `CLICKHOUSE_URL`: Connection URL (e.g., `clickhouse://host:9000`)
-- `RANGE_START`, `RANGE_END`: Unix timestamps for processing interval
+- `BOUNDS_START`, `BOUNDS_END`: Bounds for processing
 - `TASK_START`: Task execution timestamp
 - `SELF_DATABASE`, `SELF_TABLE`: Target table info
 - `DEP_<MODEL>_DATABASE`, `DEP_<MODEL>_TABLE`: Dependency info

--- a/pkg/coordinator/service.go
+++ b/pkg/coordinator/service.go
@@ -683,9 +683,6 @@ func (s *service) onTaskComplete(ctx context.Context, payload tasks.TaskPayload)
 		"position": payload.Position,
 	}).Debug("Task completed, checking dependents")
 
-	// Update model position metrics
-	observability.ModelLastPosition.WithLabelValues(payload.ModelID).Set(float64(payload.Position))
-
 	// Get models that depend on this one
 	dependents := s.dag.GetDependents(payload.ModelID)
 

--- a/pkg/scheduler/service.go
+++ b/pkg/scheduler/service.go
@@ -272,7 +272,7 @@ func (s *service) registerScheduledTask(taskType, schedule string) error {
 		}).Info("Registered consolidation task")
 
 		// Update metrics for consolidation
-		observability.ScheduledTasksRegistered.WithLabelValues("consolidation", "maintenance").Set(1)
+		observability.RecordScheduledTaskRegistered("consolidation", "maintenance")
 	} else {
 		// Regular transformation task
 		modelID := extractModelID(taskType)
@@ -290,7 +290,7 @@ func (s *service) registerScheduledTask(taskType, schedule string) error {
 		}).Info("Registered scheduled task")
 
 		// Update metrics
-		observability.ScheduledTasksRegistered.WithLabelValues(modelID, string(operation)).Set(1)
+		observability.RecordScheduledTaskRegistered(modelID, string(operation))
 	}
 
 	return nil
@@ -336,9 +336,7 @@ func (s *service) HandleScheduledForward(_ context.Context, t *asynq.Task) error
 	s.coordinator.Process(transformation, coordinator.DirectionForward)
 
 	// Record metrics
-	observability.ScheduledTaskExecutions.WithLabelValues(
-		modelID, string(coordinator.DirectionForward), "success",
-	).Inc()
+	observability.RecordScheduledTaskExecution(modelID, string(coordinator.DirectionForward), "success")
 
 	return nil
 }
@@ -420,9 +418,7 @@ func (s *service) HandleScheduledBackfill(_ context.Context, t *asynq.Task) erro
 	s.coordinator.Process(transformation, coordinator.DirectionBack)
 
 	// Record metrics
-	observability.ScheduledTaskExecutions.WithLabelValues(
-		modelID, string(coordinator.DirectionBack), "success",
-	).Inc()
+	observability.RecordScheduledTaskExecution(modelID, string(coordinator.DirectionBack), "success")
 
 	return nil
 }

--- a/pkg/validation/external.go
+++ b/pkg/validation/external.go
@@ -155,6 +155,8 @@ func (e *ExternalModelValidator) GetMinMax(ctx context.Context, model models.Ext
 
 	// Try to get from cache
 	if cachedMin, cachedMax, found := e.tryGetFromCache(ctx, model); found {
+		// Record the raw bounds in metrics
+		observability.RecordModelBounds(modelID, cachedMin, cachedMax)
 		minPos, maxPos = e.applyLag(model, cachedMin, cachedMax, true)
 		return minPos, maxPos, nil
 	}
@@ -191,6 +193,9 @@ func (e *ExternalModelValidator) GetMinMax(ctx context.Context, model models.Ext
 		// Log error but don't fail the operation - cache is not critical
 		e.log.WithError(err).WithField("model_id", model.GetID()).Debug("Failed to store in cache")
 	}
+
+	// Record the raw bounds in metrics
+	observability.RecordModelBounds(modelID, uint64(result.MinPos), uint64(result.MaxPos))
 
 	// Apply lag if configured
 	minPos, maxPos = e.applyLag(model, uint64(result.MinPos), uint64(result.MaxPos), false)

--- a/pkg/validation/validator.go
+++ b/pkg/validation/validator.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethpandaops/cbt/pkg/admin"
 	"github.com/ethpandaops/cbt/pkg/clickhouse"
 	"github.com/ethpandaops/cbt/pkg/models"
+	"github.com/ethpandaops/cbt/pkg/observability"
 	"github.com/sirupsen/logrus"
 )
 
@@ -304,6 +305,9 @@ func (v *dependencyValidator) collectTransformationBounds(ctx context.Context, d
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to get last position for %s: %w", depID, err)
 	}
+
+	// Record transformation bounds in metrics
+	observability.RecordModelBounds(depID, minDep, maxDep)
 
 	return minDep, maxDep, nil
 }


### PR DESCRIPTION
- Remove ModelPositionLag and ModelLastPosition metrics
- Add ModelBounds metric to track min/max bounds for all models
- Update environment variable names from RANGE_* to BOUNDS_*
- Consolidate metric recording through helper functions
- Apply consistent label naming (model_id -> model)