### PR TITLE
feat: add model bounds metrics recording

### DIFF
--- a/pkg/tasks/handlers.go
+++ b/pkg/tasks/handlers.go
@@ -172,6 +172,13 @@ func (h *TaskHandler) HandleTransformation(ctx context.Context, t *asynq.Task) e
 		return fmt.Errorf("failed to record completion: %w", err)
 	}
 
+	// Record transformation bounds in metrics
+	minPos, _ := h.admin.GetFirstPosition(ctx, payload.ModelID)
+	maxPos, _ := h.admin.GetLastProcessedEndPosition(ctx, payload.ModelID)
+	if minPos > 0 && maxPos > 0 {
+		observability.RecordModelBounds(payload.ModelID, minPos, maxPos)
+	}
+
 	// Record successful completion
 	observability.RecordTaskComplete(payload.ModelID, workerID, "success", time.Since(startTime).Seconds())
 

--- a/pkg/worker/executor.go
+++ b/pkg/worker/executor.go
@@ -107,6 +107,9 @@ func (e *ModelExecutor) UpdateBounds(ctx context.Context, modelID string) error 
 		return fmt.Errorf("failed to update bounds cache for %s: %w", modelID, err)
 	}
 
+	// Record the bounds in metrics
+	observability.RecordModelBounds(modelID, minBound, maxBound)
+
 	return nil
 }
 


### PR DESCRIPTION
- Record min/max position bounds in metrics after transformation completion
- Record bounds when updating bounds cache in executor