### PR TITLE
feat: database isolation via CBT_DATABASE_PREFIX

### DIFF
--- a/pkg/clickhouse/config.go
+++ b/pkg/clickhouse/config.go
@@ -3,6 +3,7 @@ package clickhouse
 
 import (
 	"errors"
+	"os"
 	"time"
 )
 
@@ -54,4 +55,14 @@ func (c *Config) SetDefaults() {
 	if c.AdminTable == "" {
 		c.AdminTable = "cbt"
 	}
+}
+
+// MapDatabase maps a logical database name to a physical database name
+// If CBT_DATABASE_PREFIX env var is set, prepends it to the database name
+// Otherwise returns the original name unchanged
+func (c *Config) MapDatabase(logicalName string) string {
+	if prefix := os.Getenv("CBT_DATABASE_PREFIX"); prefix != "" {
+		return prefix + logicalName
+	}
+	return logicalName
 }

--- a/pkg/clickhouse/config_test.go
+++ b/pkg/clickhouse/config_test.go
@@ -1,0 +1,44 @@
+package clickhouse
+
+import (
+	"os"
+	"testing"
+)
+
+func TestMapDatabase(t *testing.T) {
+	c := &Config{}
+
+	// Test without prefix
+	result := c.MapDatabase("mainnet")
+	if result != "mainnet" {
+		t.Errorf("MapDatabase without prefix: expected 'mainnet', got '%s'", result)
+	}
+
+	// Test with prefix
+	os.Setenv("CBT_DATABASE_PREFIX", "test_123_")
+	defer os.Unsetenv("CBT_DATABASE_PREFIX")
+
+	result = c.MapDatabase("mainnet")
+	if result != "test_123_mainnet" {
+		t.Errorf("MapDatabase with prefix: expected 'test_123_mainnet', got '%s'", result)
+	}
+
+	// Test admin database mapping
+	result = c.MapDatabase("admin")
+	if result != "test_123_admin" {
+		t.Errorf("MapDatabase with prefix for admin: expected 'test_123_admin', got '%s'", result)
+	}
+
+	// Test empty database name
+	result = c.MapDatabase("")
+	if result != "test_123_" {
+		t.Errorf("MapDatabase with empty name: expected 'test_123_', got '%s'", result)
+	}
+
+	// Clear prefix and test again
+	os.Unsetenv("CBT_DATABASE_PREFIX")
+	result = c.MapDatabase("mainnet")
+	if result != "mainnet" {
+		t.Errorf("MapDatabase after clearing prefix: expected 'mainnet', got '%s'", result)
+	}
+}

--- a/pkg/models/template.go
+++ b/pkg/models/template.go
@@ -57,7 +57,7 @@ func (t *TemplateEngine) buildTransformationVariables(model Transformation, posi
 			"local_suffix": t.clickhouseCfg.LocalSuffix,
 		},
 		"self": map[string]interface{}{
-			"database": config.Database,
+			"database": t.clickhouseCfg.MapDatabase(config.Database),
 			"table":    config.Table,
 			"interval": interval, // Use the interval parameter passed to the function
 		},
@@ -93,7 +93,7 @@ func (t *TemplateEngine) buildTransformationVariables(model Transformation, posi
 			}
 
 			database[tConfig.Table] = map[string]interface{}{
-				"database": tConfig.Database,
+				"database": t.clickhouseCfg.MapDatabase(tConfig.Database),
 				"table":    tConfig.Table,
 			}
 
@@ -134,7 +134,7 @@ func (t *TemplateEngine) GetTransformationEnvironmentVariables(model Transformat
 
 	env := []string{
 		fmt.Sprintf("CLICKHOUSE_URL=%s", t.clickhouseCfg.URL),
-		fmt.Sprintf("SELF_DATABASE=%s", config.Database),
+		fmt.Sprintf("SELF_DATABASE=%s", t.clickhouseCfg.MapDatabase(config.Database)),
 		fmt.Sprintf("SELF_TABLE=%s", config.Table),
 		fmt.Sprintf("TASK_START=%d", startTime.Unix()),
 		fmt.Sprintf("TASK_MODEL=%s.%s", config.Database, config.Table),
@@ -166,7 +166,7 @@ func (t *TemplateEngine) GetTransformationEnvironmentVariables(model Transformat
 			tConfig := transformation.GetConfig()
 
 			env = append(env,
-				fmt.Sprintf("DEP_%s_DATABASE=%s", uppercaseName, tConfig.Database),
+				fmt.Sprintf("DEP_%s_DATABASE=%s", uppercaseName, t.clickhouseCfg.MapDatabase(tConfig.Database)),
 				fmt.Sprintf("DEP_%s_TABLE=%s", uppercaseName, tConfig.Table),
 			)
 		}
@@ -180,7 +180,7 @@ func (t *TemplateEngine) GetTransformationEnvironmentVariables(model Transformat
 			eConfig := external.GetConfig()
 
 			env = append(env,
-				fmt.Sprintf("DEP_%s_DATABASE=%s", uppercaseName, eConfig.Database),
+				fmt.Sprintf("DEP_%s_DATABASE=%s", uppercaseName, t.clickhouseCfg.MapDatabase(eConfig.Database)),
 				fmt.Sprintf("DEP_%s_TABLE=%s", uppercaseName, eConfig.Table),
 			)
 		}
@@ -215,7 +215,7 @@ func (t *TemplateEngine) buildExternalVariables(model External, cacheState map[s
 			"local_suffix": t.clickhouseCfg.LocalSuffix,
 		},
 		"self": map[string]interface{}{
-			"database": config.Database,
+			"database": t.clickhouseCfg.MapDatabase(config.Database),
 			"table":    config.Table,
 		},
 	}


### PR DESCRIPTION
## Summary
- Added database isolation support through `CBT_DATABASE_PREFIX` environment variable
- Enables parallel testing with isolated database namespaces

