### PR TITLE
feat: add partial interval processing support for forward fill operations

### DIFF
--- a/example/models/transformations/blocks/block_entity.sql
+++ b/example/models/transformations/blocks/block_entity.sql
@@ -4,6 +4,8 @@ table: block_entity
 forwardfill:
   interval: 60
   schedule: "@every 10s"
+  allow_partial_intervals: true
+  min_partial_interval: 40
 backfill:
   interval: 60
   schedule: "@every 10s"

--- a/example/models/transformations/blocks/block_propagation.sql
+++ b/example/models/transformations/blocks/block_propagation.sql
@@ -4,6 +4,7 @@ table: block_propagation
 forwardfill:
   interval: 60
   schedule: "@every 10s"
+  allow_partial_intervals: true
 backfill:
   interval: 60
   schedule: "@every 10s"


### PR DESCRIPTION
Allow transformations to process partial intervals when dependencies have limited data available, reducing processing lag. Includes configurable minimum partial interval size to prevent excessively small processing chunks.

Key changes:
- Add allow_partial_intervals and min_partial_interval config options
- Implement partial interval adjustment based on dependency availability
- Add comprehensive test coverage for partial interval logic
- Update documentation with detailed validation flow and examples