### PR TITLE
refactor: decouple archive handler from DAG dependency

### DIFF
--- a/pkg/coordinator/service.go
+++ b/pkg/coordinator/service.go
@@ -105,7 +105,7 @@ func (s *service) Start(ctx context.Context) error {
 
 	s.inspector = asynq.NewInspector(*asynqRedis)
 
-	archiveHandler, err := NewArchiveHandler(s.log, s.redisOpt, s.dag)
+	archiveHandler, err := NewArchiveHandler(s.log, s.redisOpt)
 	if err != nil {
 		return fmt.Errorf("failed to create archive handler: %w", err)
 	}


### PR DESCRIPTION
- Remove DAG reader dependency from archive handler
- Dynamically discover queues from asynq inspector instead of using transformation nodes
- Increase archive check interval from 30s to 10 minutes for efficiency
- Improve logging with total deletion count and warning level for deletions
- Make task payload parsing optional for enrichment