### PR TITLE
refactor: unify interval configuration for forward and backfill processing

### DIFF
--- a/example/models/transformations/blocks/block_entity.sql
+++ b/example/models/transformations/blocks/block_entity.sql
@@ -1,14 +1,12 @@
 ---
 database: analytics
 table: block_entity
-forwardfill:
-  interval: 60
-  schedule: "@every 10s"
-  allow_partial_intervals: true
-  min_partial_interval: 40
-backfill:
-  interval: 60
-  schedule: "@every 10s"
+interval:
+  max: 60
+  min: 40  # Allow partial intervals down to 40 seconds
+schedules:
+  forwardfill: "@every 10s"
+  backfill: "@every 10s"
 tags:
   - entity
   - block

--- a/example/models/transformations/blocks/block_propagation.sql
+++ b/example/models/transformations/blocks/block_propagation.sql
@@ -1,13 +1,12 @@
 ---
 database: analytics
 table: block_propagation
-forwardfill:
-  interval: 60
-  schedule: "@every 10s"
-  allow_partial_intervals: true
-backfill:
-  interval: 60
-  schedule: "@every 10s"
+interval:
+  max: 60
+  min: 0  # Allow any size partial intervals
+schedules:
+  forwardfill: "@every 10s"
+  backfill: "@every 10s"
 tags:
   - propagation
   - block

--- a/example/models/transformations/blocks/block_stats.sql
+++ b/example/models/transformations/blocks/block_stats.sql
@@ -4,12 +4,12 @@ table: hourly_block_stats
 limits:
   min: 1000  # Optional: minimum position to process
   max: 0     # Optional: maximum position to process (0 = no limit)
-forwardfill:
-  interval: 3600
-  schedule: "@every 5m"
-backfill:
-  interval: 3600
-  schedule: "@every 5m"
+interval:
+  max: 3600
+  min: 0     # Allow any size partial intervals
+schedules:
+  forwardfill: "@every 5m"
+  backfill: "@every 5m"
 tags:
   - aggregation
   - hourly

--- a/example/models/transformations/entities/entity_changes.yml
+++ b/example/models/transformations/entities/entity_changes.yml
@@ -1,11 +1,11 @@
 database: analytics
 table: entity_changes
-forwardfill:
-  interval: 120  # 2 minute intervals
-  schedule: "@every 1m"
-backfill:
-  interval: 120  # Same as forward fill, but can be different if needed
-  schedule: "@every 5m"
+interval:
+  max: 120  # 2 minute intervals
+  min: 0    # Allow any size partial intervals
+schedules:
+  forwardfill: "@every 1m"
+  backfill: "@every 5m"
 tags:
   - python
   - entity

--- a/example/models/transformations/entities/entity_network_effects.sql
+++ b/example/models/transformations/entities/entity_network_effects.sql
@@ -1,12 +1,12 @@
 ---
 database: analytics
 table: entity_network_effects
-forwardfill:
-  interval: 300
-  schedule: "@every 30s"
-backfill:
-  interval: 300
-  schedule: "@every 30s"
+interval:
+  max: 300
+  min: 0  # Allow any size partial intervals
+schedules:
+  forwardfill: "@every 30s"
+  backfill: "@every 30s"
 tags:
   - aggregation
   - entity

--- a/pkg/models/template_test.go
+++ b/pkg/models/template_test.go
@@ -75,9 +75,12 @@ func TestRenderTransformation(t *testing.T) {
 		config: transformation.Config{
 			Database: "dep_db",
 			Table:    "model1",
-			ForwardFill: &transformation.ForwardFillConfig{
-				Interval: 100,
-				Schedule: "@every 1m",
+			Interval: &transformation.IntervalConfig{
+				Max: 100,
+				Min: 0,
+			},
+			Schedules: &transformation.SchedulesConfig{
+				ForwardFill: "@every 1m",
 			},
 			Dependencies: []string{},
 		},
@@ -104,9 +107,12 @@ func TestRenderTransformation(t *testing.T) {
 				config: transformation.Config{
 					Database: "test_db",
 					Table:    "test_table",
-					ForwardFill: &transformation.ForwardFillConfig{
-						Interval: 100,
-						Schedule: "@every 1m",
+					Interval: &transformation.IntervalConfig{
+						Max: 100,
+						Min: 0,
+					},
+					Schedules: &transformation.SchedulesConfig{
+						ForwardFill: "@every 1m",
 					},
 					Dependencies: []string{},
 				},
@@ -124,9 +130,12 @@ func TestRenderTransformation(t *testing.T) {
 				config: transformation.Config{
 					Database: "test_db",
 					Table:    "test_table2",
-					ForwardFill: &transformation.ForwardFillConfig{
-						Interval: 100,
-						Schedule: "@every 1m",
+					Interval: &transformation.IntervalConfig{
+						Max: 100,
+						Min: 0,
+					},
+					Schedules: &transformation.SchedulesConfig{
+						ForwardFill: "@every 1m",
 					},
 					Dependencies: []string{"dep.model1"},
 				},
@@ -144,9 +153,12 @@ func TestRenderTransformation(t *testing.T) {
 				config: transformation.Config{
 					Database: "test_db",
 					Table:    "test_table3",
-					ForwardFill: &transformation.ForwardFillConfig{
-						Interval: 100,
-						Schedule: "@every 1m",
+					Interval: &transformation.IntervalConfig{
+						Max: 100,
+						Min: 0,
+					},
+					Schedules: &transformation.SchedulesConfig{
+						ForwardFill: "@every 1m",
 					},
 					Dependencies: []string{},
 				},
@@ -164,9 +176,12 @@ func TestRenderTransformation(t *testing.T) {
 				config: transformation.Config{
 					Database: "test_db",
 					Table:    "test_table4",
-					ForwardFill: &transformation.ForwardFillConfig{
-						Interval: 100,
-						Schedule: "@every 1m",
+					Interval: &transformation.IntervalConfig{
+						Max: 100,
+						Min: 0,
+					},
+					Schedules: &transformation.SchedulesConfig{
+						ForwardFill: "@every 1m",
 					},
 					Dependencies: []string{},
 				},
@@ -285,9 +300,12 @@ func TestGetTransformationEnvironmentVariables(t *testing.T) {
 		config: transformation.Config{
 			Database: "dep_db",
 			Table:    "model1",
-			ForwardFill: &transformation.ForwardFillConfig{
-				Interval: 100,
-				Schedule: "@every 1m",
+			Interval: &transformation.IntervalConfig{
+				Max: 100,
+				Min: 0,
+			},
+			Schedules: &transformation.SchedulesConfig{
+				ForwardFill: "@every 1m",
 			},
 			Dependencies: []string{},
 		},
@@ -313,9 +331,12 @@ func TestGetTransformationEnvironmentVariables(t *testing.T) {
 		config: transformation.Config{
 			Database: "test_db",
 			Table:    "test_table",
-			ForwardFill: &transformation.ForwardFillConfig{
-				Interval: 100,
-				Schedule: "@every 1m",
+			Interval: &transformation.IntervalConfig{
+				Max: 100,
+				Min: 0,
+			},
+			Schedules: &transformation.SchedulesConfig{
+				ForwardFill: "@every 1m",
 			},
 			Dependencies: []string{"dep.model1", "ext.source1"},
 		},
@@ -371,9 +392,12 @@ func TestBuildTransformationVariables_MissingDependency(t *testing.T) {
 		config: transformation.Config{
 			Database: "test_db",
 			Table:    "test_table",
-			ForwardFill: &transformation.ForwardFillConfig{
-				Interval: 100,
-				Schedule: "@every 1m",
+			Interval: &transformation.IntervalConfig{
+				Max: 100,
+				Min: 0,
+			},
+			Schedules: &transformation.SchedulesConfig{
+				ForwardFill: "@every 1m",
 			},
 			Dependencies: []string{"missing.dep"},
 		},
@@ -401,9 +425,12 @@ func BenchmarkRenderTransformation(b *testing.B) {
 		config: transformation.Config{
 			Database: "test_db",
 			Table:    "test_table",
-			ForwardFill: &transformation.ForwardFillConfig{
-				Interval: 100,
-				Schedule: "@every 1m",
+			Interval: &transformation.IntervalConfig{
+				Max: 100,
+				Min: 0,
+			},
+			Schedules: &transformation.SchedulesConfig{
+				ForwardFill: "@every 1m",
 			},
 			Dependencies: []string{},
 		},

--- a/pkg/scheduler/service_test.go
+++ b/pkg/scheduler/service_test.go
@@ -286,13 +286,13 @@ func TestHandleScheduledBackfill(t *testing.T) {
 						conf: transformation.Config{
 							Database: "test_db",
 							Table:    "model",
-							ForwardFill: &transformation.ForwardFillConfig{
-								Interval: 100,
-								Schedule: "@every 1m",
+							Interval: &transformation.IntervalConfig{
+								Max: 100,
+								Min: 0,
 							},
-							Backfill: &transformation.BackfillConfig{
-								Interval: 100,
-								Schedule: "*/5 * * * *",
+							Schedules: &transformation.SchedulesConfig{
+								ForwardFill: "@every 1m",
+								Backfill:    "*/5 * * * *",
 							},
 							Dependencies: []string{},
 						},

--- a/pkg/validation/validator.go
+++ b/pkg/validation/validator.go
@@ -181,7 +181,7 @@ func (v *dependencyValidator) GetEarliestPosition(ctx context.Context, modelID s
 	if !ok {
 		return 0, fmt.Errorf("%w: %s", ErrFailedModelCast, modelID)
 	}
-	interval := model.GetConfig().GetBackfillInterval()
+	interval := model.GetConfig().GetMaxInterval()
 
 	// For backfill gap detection, we want to start from where data is available
 	// Don't round up past the actual data availability point
@@ -235,7 +235,7 @@ func (v *dependencyValidator) GetInitialPosition(ctx context.Context, modelID st
 	if !ok {
 		return 0, fmt.Errorf("%w: %s", ErrFailedModelCast, modelID)
 	}
-	interval := model.GetConfig().GetForwardInterval()
+	interval := model.GetConfig().GetMaxInterval()
 
 	// Use GetValidRange to get the valid range
 	_, maxPos, err := v.GetValidRange(ctx, modelID)

--- a/pkg/validation/validator_test.go
+++ b/pkg/validation/validator_test.go
@@ -546,9 +546,12 @@ func (m *mockTransformation) GetConfig() *transformation.Config {
 	return &transformation.Config{
 		Database: "test_db",
 		Table:    "test_table",
-		ForwardFill: &transformation.ForwardFillConfig{
-			Interval: m.interval,
-			Schedule: "@every 1m",
+		Interval: &transformation.IntervalConfig{
+			Max: m.interval,
+			Min: 0,
+		},
+		Schedules: &transformation.SchedulesConfig{
+			ForwardFill: "@every 1m",
 		},
 		Dependencies: []string{},
 	}

--- a/pkg/worker/service_test.go
+++ b/pkg/worker/service_test.go
@@ -336,9 +336,12 @@ func (m *mockTransformation) GetConfig() *transformation.Config {
 	return &transformation.Config{
 		Database: "test_db",
 		Table:    "test_table",
-		ForwardFill: &transformation.ForwardFillConfig{
-			Interval: m.interval,
-			Schedule: "@every 1m",
+		Interval: &transformation.IntervalConfig{
+			Max: m.interval,
+			Min: 0,
+		},
+		Schedules: &transformation.SchedulesConfig{
+			ForwardFill: "@every 1m",
 		},
 		Tags:         m.tags,
 		Dependencies: []string{},


### PR DESCRIPTION
Replace separate ForwardFill and Backfill configs with unified Interval and Schedules configurations. This simplifies the config structure and enables flexible partial interval processing through min/max interval boundaries.

- Consolidate interval settings under single 'interval' config with min/max bounds
- Move schedules to dedicated 'schedules' section with forwardfill and backfill options
- Support partial interval processing when interval.min < interval.max
- Update all example models and tests to use new configuration format
- Maintain backward compatibility for existing processing logic