### PR TITLE
feat: add default database configuration for models with dependency placeholders

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -69,15 +69,17 @@ worker:
   # Seconds to wait for graceful shutdown
   shutdownTimeout: 30
 
-# Model paths configuration (optional)
-# Configure where to find external and transformation models
+# Model configuration (optional)
+# Configure where to find external and transformation models and default database
 # Defaults to models/external and models/transformations if not specified
 # models:
 #   external:
+#     defaultDatabase: ethereum # optional
 #     paths:
-#       - "models/external"
+#       - "models/external" # default
 #       - "/additional/external/models"
 #   transformations:
+#     defaultDatabase: analytics # optional
 #     paths:
-#       - "models/transformations"
+#       - "models/transformations" # default
 #       - "/additional/transformation/models"

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -45,11 +45,13 @@ worker:
   #   require: []
   shutdownTimeout: 30
 
-# Model paths configuration
+# Model configuration with optional default databases
 models:
   external:
     paths:
       - "/app/models/external"
+    defaultDatabase: "ethereum"  # Default database for external models
   transformations:
     paths:
       - "/app/models/transformations"
+    defaultDatabase: "analytics"  # Default database for transformation models

--- a/example/models/external/beacon/blocks/beacon_blocks.sql
+++ b/example/models/external/beacon/blocks/beacon_blocks.sql
@@ -1,5 +1,6 @@
 ---
-database: ethereum
+# database is set in the config models.external.defaultDatabase
+# database: ethereum
 table: beacon_blocks
 cache:
   incremental_scan_interval: 10s

--- a/example/models/external/validators/validator_entity.sql
+++ b/example/models/external/validators/validator_entity.sql
@@ -1,5 +1,6 @@
 ---
-database: ethereum
+# database is set in the config models.external.defaultDatabase
+# database: ethereum
 table: validator_entity
 cache:
   incremental_scan_interval: 10s

--- a/example/models/transformations/blocks/block_entity.sql
+++ b/example/models/transformations/blocks/block_entity.sql
@@ -1,5 +1,6 @@
 ---
-database: analytics
+# database is set in the config models.transformations.defaultDatabase
+# database: analytics
 table: block_entity
 interval:
   max: 60
@@ -11,8 +12,8 @@ tags:
   - entity
   - block
 dependencies:
-  - ethereum.beacon_blocks
-  - ethereum.validator_entity
+  - "{{external}}.beacon_blocks"
+  - "{{external}}.validator_entity"
 ---
 INSERT INTO
   `{{ .self.database }}`.`{{ .self.table }}`

--- a/example/models/transformations/blocks/block_propagation.sql
+++ b/example/models/transformations/blocks/block_propagation.sql
@@ -1,5 +1,6 @@
 ---
-database: analytics
+# database is set in the config models.transformations.defaultDatabase
+# database: analytics
 table: block_propagation
 interval:
   max: 60
@@ -11,7 +12,7 @@ tags:
   - propagation
   - block
 dependencies:
-  - ethereum.beacon_blocks
+  - "{{external}}.beacon_blocks"
 ---
 INSERT INTO
   `{{ .self.database }}`.`{{ .self.table }}`

--- a/example/models/transformations/blocks/block_stats.sql
+++ b/example/models/transformations/blocks/block_stats.sql
@@ -1,5 +1,6 @@
 ---
-database: analytics
+# database is set in the config models.transformations.defaultDatabase
+# database: analytics
 table: hourly_block_stats
 limits:
   min: 1000  # Optional: minimum position to process
@@ -14,7 +15,7 @@ tags:
   - aggregation
   - hourly
 dependencies:
-  - analytics.block_entity
+  - "{{transformation}}.block_entity"
 ---
 -- Hourly aggregation of block statistics
 -- Demonstrates nested directory model structure

--- a/example/models/transformations/entities/entity_changes.yml
+++ b/example/models/transformations/entities/entity_changes.yml
@@ -1,4 +1,5 @@
-database: analytics
+# database is set in the config models.transformations.defaultDatabase
+# database: analytics
 table: entity_changes
 interval:
   max: 120  # 2 minute intervals
@@ -11,5 +12,5 @@ tags:
   - entity
   - metrics
 dependencies:
-  - ethereum.validator_entity
+  - "{{external}}.validator_entity"
 exec: "python3 /app/scripts/entity_changes.py"

--- a/example/models/transformations/entities/entity_network_effects.sql
+++ b/example/models/transformations/entities/entity_network_effects.sql
@@ -1,5 +1,6 @@
 ---
-database: analytics
+# database is set in the config models.transformations.defaultDatabase
+# database: analytics
 table: entity_network_effects
 interval:
   max: 300
@@ -12,8 +13,10 @@ tags:
   - entity
   - network
 dependencies:
-  - analytics.block_entity
-  - analytics.block_propagation
+  # you can use the models.transformations.defaultDatabase template variable here
+  - "{{transformation}}.block_entity"
+  # or directly reference the analytics database
+  - "analytics.block_propagation"
 ---
 INSERT INTO
   `{{ .self.database }}`.`{{ .self.table }}`

--- a/pkg/coordinator/service_test.go
+++ b/pkg/coordinator/service_test.go
@@ -285,6 +285,11 @@ func (m *mockTransformation) GetDependencies() []string         { return []strin
 func (m *mockTransformation) GetSQL() string                    { return "" }
 func (m *mockTransformation) GetType() string                   { return "transformation" }
 func (m *mockTransformation) GetEnvironmentVariables() []string { return []string{} }
+func (m *mockTransformation) SetDefaultDatabase(defaultDB string) {
+	if m.config != nil && m.config.Database == "" {
+		m.config.Database = defaultDB
+	}
+}
 
 // Ensure mockTransformation implements the Transformation interface
 var _ models.Transformation = (*mockTransformation)(nil)

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -2,18 +2,20 @@ package models
 
 // Config represents the complete coordinator configuration
 type Config struct {
-	External       ExternalPathsConfig       `yaml:"external"`
-	Transformation TransformationPathsConfig `yaml:"transformations"`
+	External       ExternalConfig       `yaml:"external"`
+	Transformation TransformationConfig `yaml:"transformations"`
 }
 
-// ExternalPathsConfig defines paths for external model discovery
-type ExternalPathsConfig struct {
-	Paths []string `yaml:"paths"`
+// ExternalConfig defines configuration for external models
+type ExternalConfig struct {
+	Paths           []string `yaml:"paths"`
+	DefaultDatabase string   `yaml:"defaultDatabase"`
 }
 
-// TransformationPathsConfig defines paths for transformation model discovery
-type TransformationPathsConfig struct {
-	Paths []string `yaml:"paths"`
+// TransformationConfig defines configuration for transformation models
+type TransformationConfig struct {
+	Paths           []string `yaml:"paths"`
+	DefaultDatabase string   `yaml:"defaultDatabase"`
 }
 
 // Validate validates and sets defaults for the configuration
@@ -25,14 +27,14 @@ func (c *Config) Validate() error {
 }
 
 // SetDefaults sets default paths for external models
-func (c *ExternalPathsConfig) SetDefaults() {
+func (c *ExternalConfig) SetDefaults() {
 	if len(c.Paths) == 0 {
 		c.Paths = []string{"models/external"}
 	}
 }
 
 // SetDefaults sets default paths for transformation models
-func (c *TransformationPathsConfig) SetDefaults() {
+func (c *TransformationConfig) SetDefaults() {
 	if len(c.Paths) == 0 {
 		c.Paths = []string{"models/transformations"}
 	}

--- a/pkg/models/dag_test.go
+++ b/pkg/models/dag_test.go
@@ -17,13 +17,14 @@ type mockTransformation struct {
 	config       transformation.Config
 }
 
-func (m *mockTransformation) GetID() string                     { return m.id }
-func (m *mockTransformation) GetDependencies() []string         { return m.dependencies }
-func (m *mockTransformation) GetConfig() *transformation.Config { return &m.config }
-func (m *mockTransformation) GetSQL() string                    { return "" }
-func (m *mockTransformation) GetType() string                   { return "transformation" }
-func (m *mockTransformation) GetValue() string                  { return "" }
-func (m *mockTransformation) GetEnvironmentVariables() []string { return []string{} }
+func (m *mockTransformation) GetID() string                       { return m.id }
+func (m *mockTransformation) GetDependencies() []string           { return m.dependencies }
+func (m *mockTransformation) GetConfig() *transformation.Config   { return &m.config }
+func (m *mockTransformation) GetSQL() string                      { return "" }
+func (m *mockTransformation) GetType() string                     { return "transformation" }
+func (m *mockTransformation) GetValue() string                    { return "" }
+func (m *mockTransformation) GetEnvironmentVariables() []string   { return []string{} }
+func (m *mockTransformation) SetDefaultDatabase(defaultDB string) { m.config.SetDefaults(defaultDB) }
 
 // Mock external for testing
 type mockExternal struct {
@@ -32,12 +33,13 @@ type mockExternal struct {
 	typ    string
 }
 
-func (m *mockExternal) GetID() string                     { return m.id }
-func (m *mockExternal) GetConfig() external.Config        { return m.config }
-func (m *mockExternal) GetType() string                   { return m.typ }
-func (m *mockExternal) GetSQL() string                    { return "" }
-func (m *mockExternal) GetValue() string                  { return "" }
-func (m *mockExternal) GetEnvironmentVariables() []string { return []string{} }
+func (m *mockExternal) GetID() string                       { return m.id }
+func (m *mockExternal) GetConfig() external.Config          { return m.config }
+func (m *mockExternal) GetType() string                     { return m.typ }
+func (m *mockExternal) GetSQL() string                      { return "" }
+func (m *mockExternal) GetValue() string                    { return "" }
+func (m *mockExternal) GetEnvironmentVariables() []string   { return []string{} }
+func (m *mockExternal) SetDefaultDatabase(defaultDB string) { m.config.SetDefaults(defaultDB) }
 
 // Test NewDependencyGraph
 func TestNewDependencyGraph(t *testing.T) {

--- a/pkg/models/external.go
+++ b/pkg/models/external.go
@@ -27,6 +27,7 @@ type External interface {
 	GetID() string
 	GetConfig() external.Config
 	GetValue() string
+	SetDefaultDatabase(defaultDB string)
 }
 
 // NewExternal creates a new external model from file content

--- a/pkg/models/external/config.go
+++ b/pkg/models/external/config.go
@@ -30,7 +30,7 @@ type CacheConfig struct {
 
 // Config defines configuration for external models
 type Config struct {
-	Database string       `yaml:"database" validate:"required"`
+	Database string       `yaml:"database"` // Optional, can fall back to default
 	Table    string       `yaml:"table" validate:"required"`
 	Cache    *CacheConfig `yaml:"cache"`
 	Lag      uint64       `yaml:"lag"`
@@ -64,6 +64,13 @@ func (c *Config) Validate() error {
 	}
 
 	return nil
+}
+
+// SetDefaults applies default values to the configuration
+func (c *Config) SetDefaults(defaultDatabase string) {
+	if c.Database == "" && defaultDatabase != "" {
+		c.Database = defaultDatabase
+	}
 }
 
 // GetID returns the unique identifier for the external model

--- a/pkg/models/external/config_test.go
+++ b/pkg/models/external/config_test.go
@@ -1,0 +1,122 @@
+package external
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigSetDefaults(t *testing.T) {
+	tests := []struct {
+		name            string
+		config          *Config
+		defaultDatabase string
+		expectedDB      string
+	}{
+		{
+			name: "apply default when database is empty",
+			config: &Config{
+				Table: "test_table",
+				Cache: &CacheConfig{
+					IncrementalScanInterval: time.Minute,
+					FullScanInterval:        time.Hour,
+				},
+			},
+			defaultDatabase: "default_db",
+			expectedDB:      "default_db",
+		},
+		{
+			name: "keep existing database when already set",
+			config: &Config{
+				Database: "existing_db",
+				Table:    "test_table",
+				Cache: &CacheConfig{
+					IncrementalScanInterval: time.Minute,
+					FullScanInterval:        time.Hour,
+				},
+			},
+			defaultDatabase: "default_db",
+			expectedDB:      "existing_db",
+		},
+		{
+			name: "no change when default is empty",
+			config: &Config{
+				Table: "test_table",
+				Cache: &CacheConfig{
+					IncrementalScanInterval: time.Minute,
+					FullScanInterval:        time.Hour,
+				},
+			},
+			defaultDatabase: "",
+			expectedDB:      "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.config.SetDefaults(tt.defaultDatabase)
+			assert.Equal(t, tt.expectedDB, tt.config.Database)
+		})
+	}
+}
+
+func TestConfigValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  *Config
+		wantErr bool
+		errMsg  error
+	}{
+		{
+			name: "valid config with database set",
+			config: &Config{
+				Database: "test_db",
+				Table:    "test_table",
+				Cache: &CacheConfig{
+					IncrementalScanInterval: time.Minute,
+					FullScanInterval:        time.Hour,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid config without database",
+			config: &Config{
+				Table: "test_table",
+				Cache: &CacheConfig{
+					IncrementalScanInterval: time.Minute,
+					FullScanInterval:        time.Hour,
+				},
+			},
+			wantErr: true,
+			errMsg:  ErrDatabaseRequired,
+		},
+		{
+			name: "invalid config without table",
+			config: &Config{
+				Database: "test_db",
+				Cache: &CacheConfig{
+					IncrementalScanInterval: time.Minute,
+					FullScanInterval:        time.Hour,
+				},
+			},
+			wantErr: true,
+			errMsg:  ErrTableRequired,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errMsg != nil {
+					assert.Equal(t, tt.errMsg, err)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/models/external/sql.go
+++ b/pkg/models/external/sql.go
@@ -72,3 +72,8 @@ func (c *SQL) GetConfig() Config {
 func (c *SQL) GetValue() string {
 	return c.Content
 }
+
+// SetDefaultDatabase applies the default database if not already set
+func (c *SQL) SetDefaultDatabase(defaultDB string) {
+	c.SetDefaults(defaultDB)
+}

--- a/pkg/models/service_test.go
+++ b/pkg/models/service_test.go
@@ -1,0 +1,350 @@
+package models
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ethpandaops/cbt/pkg/clickhouse"
+	"github.com/redis/go-redis/v9"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServiceWithDefaultDatabases(t *testing.T) {
+	tests := []struct {
+		name                     string
+		config                   *Config
+		expectedExternalDB       string
+		expectedTransformationDB string
+	}{
+		{
+			name: "both model types have different default databases",
+			config: &Config{
+				External: ExternalConfig{
+					Paths:           []string{},
+					DefaultDatabase: "raw_data",
+				},
+				Transformation: TransformationConfig{
+					Paths:           []string{},
+					DefaultDatabase: "analytics",
+				},
+			},
+			expectedExternalDB:       "raw_data",
+			expectedTransformationDB: "analytics",
+		},
+		{
+			name: "both model types have same default database",
+			config: &Config{
+				External: ExternalConfig{
+					Paths:           []string{},
+					DefaultDatabase: "shared_db",
+				},
+				Transformation: TransformationConfig{
+					Paths:           []string{},
+					DefaultDatabase: "shared_db",
+				},
+			},
+			expectedExternalDB:       "shared_db",
+			expectedTransformationDB: "shared_db",
+		},
+		{
+			name: "only external has default database",
+			config: &Config{
+				External: ExternalConfig{
+					Paths:           []string{},
+					DefaultDatabase: "external_db",
+				},
+				Transformation: TransformationConfig{
+					Paths:           []string{},
+					DefaultDatabase: "",
+				},
+			},
+			expectedExternalDB:       "external_db",
+			expectedTransformationDB: "",
+		},
+		{
+			name: "only transformation has default database",
+			config: &Config{
+				External: ExternalConfig{
+					Paths:           []string{},
+					DefaultDatabase: "",
+				},
+				Transformation: TransformationConfig{
+					Paths:           []string{},
+					DefaultDatabase: "trans_db",
+				},
+			},
+			expectedExternalDB:       "",
+			expectedTransformationDB: "trans_db",
+		},
+		{
+			name: "neither has default database",
+			config: &Config{
+				External: ExternalConfig{
+					Paths: []string{},
+				},
+				Transformation: TransformationConfig{
+					Paths: []string{},
+				},
+			},
+			expectedExternalDB:       "",
+			expectedTransformationDB: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Validate config sets defaults properly
+			err := tt.config.Validate()
+			assert.NoError(t, err)
+
+			// Check that default databases are correctly set
+			assert.Equal(t, tt.expectedExternalDB, tt.config.External.DefaultDatabase)
+			assert.Equal(t, tt.expectedTransformationDB, tt.config.Transformation.DefaultDatabase)
+
+			// Verify that paths are set to defaults when empty
+			assert.Equal(t, []string{"models/external"}, tt.config.External.Paths)
+			assert.Equal(t, []string{"models/transformations"}, tt.config.Transformation.Paths)
+		})
+	}
+}
+
+func TestServiceCreation(t *testing.T) {
+	log := logrus.New()
+	log.SetLevel(logrus.DebugLevel)
+
+	// Create a config with default databases
+	cfg := &Config{
+		External: ExternalConfig{
+			Paths:           []string{"testdata/external"},
+			DefaultDatabase: "test_external_db",
+		},
+		Transformation: TransformationConfig{
+			Paths:           []string{"testdata/transformations"},
+			DefaultDatabase: "test_trans_db",
+		},
+	}
+
+	clickhouseCfg := &clickhouse.Config{
+		URL:         "http://localhost:8123",
+		Cluster:     "test_cluster",
+		LocalSuffix: "_local",
+	}
+
+	// Create service (without actual Redis connection for unit test)
+	svc, err := NewService(log, cfg, (*redis.Client)(nil), clickhouseCfg)
+	require.NoError(t, err)
+	require.NotNil(t, svc)
+
+	// Verify the service was created successfully
+	// The actual default database application is tested in the individual model tests
+	assert.Equal(t, "test_external_db", cfg.External.DefaultDatabase)
+	assert.Equal(t, "test_trans_db", cfg.Transformation.DefaultDatabase)
+}
+
+func TestServiceDependencyPlaceholders(t *testing.T) {
+	// Create temporary directories for test models
+	transformationDir := t.TempDir()
+	externalDir := t.TempDir()
+
+	// Create external models that will be referenced
+	externalContent1 := `---
+table: beacon_blocks
+cache:
+  incremental_scan_interval: 1m
+  full_scan_interval: 1h
+---
+SELECT * FROM test`
+
+	externalContent2 := `---
+database: custom_db
+table: custom_table
+cache:
+  incremental_scan_interval: 1m
+  full_scan_interval: 1h
+---
+SELECT * FROM test`
+
+	// Write external models
+	err := os.WriteFile(filepath.Join(externalDir, "beacon_blocks.sql"), []byte(externalContent1), 0o644)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(externalDir, "custom.sql"), []byte(externalContent2), 0o644)
+	require.NoError(t, err)
+
+	// Create transformation models with placeholder dependencies
+	transformationContent := `table: test_transform
+interval:
+  max: 100
+  min: 10
+schedules:
+  forwardfill: "0 * * * *"
+dependencies:
+  - "{{external}}.beacon_blocks"
+  - "{{transformation}}.other_transform"
+  - custom_db.custom_table
+exec: "echo test"`
+
+	err = os.WriteFile(filepath.Join(transformationDir, "test.yml"), []byte(transformationContent), 0o644)
+	require.NoError(t, err)
+
+	// Create another transformation that uses default database
+	transformationContent2 := `table: other_transform
+interval:
+  max: 100
+  min: 10
+schedules:
+  forwardfill: "0 * * * *"
+dependencies:
+  - "{{external}}.beacon_blocks"
+exec: "echo test"`
+
+	err = os.WriteFile(filepath.Join(transformationDir, "other.yml"), []byte(transformationContent2), 0o644)
+	require.NoError(t, err)
+
+	log := logrus.New()
+	log.SetLevel(logrus.DebugLevel)
+
+	clickhouseCfg := &clickhouse.Config{
+		URL:         "http://localhost:8123",
+		Cluster:     "test_cluster",
+		LocalSuffix: "_local",
+	}
+
+	config := &Config{
+		External: ExternalConfig{
+			Paths:           []string{externalDir},
+			DefaultDatabase: "ethereum",
+		},
+		Transformation: TransformationConfig{
+			Paths:           []string{transformationDir},
+			DefaultDatabase: "analytics",
+		},
+	}
+
+	svc, err := NewService(log, config, nil, clickhouseCfg)
+	require.NoError(t, err)
+
+	err = svc.Start()
+	require.NoError(t, err)
+
+	// Get the service implementation to access transformationModels
+	s := svc.(*service)
+
+	// Verify dependencies were substituted correctly
+	for _, model := range s.transformationModels {
+		cfg := model.GetConfig()
+		for _, dep := range cfg.Dependencies {
+			// Should not contain any placeholders
+			assert.NotContains(t, dep, "{{external}}")
+			assert.NotContains(t, dep, "{{transformation}}")
+
+			// Check specific substitutions
+			if cfg.Table == "test_transform" {
+				assert.Contains(t, cfg.Dependencies, "ethereum.beacon_blocks")
+				assert.Contains(t, cfg.Dependencies, "analytics.other_transform")
+				assert.Contains(t, cfg.Dependencies, "custom_db.custom_table")
+			}
+			if cfg.Table == "other_transform" {
+				assert.Contains(t, cfg.Dependencies, "ethereum.beacon_blocks")
+			}
+		}
+	}
+}
+
+func TestServiceValidatesDatabase(t *testing.T) {
+	// Create temporary directories for test models
+	transformationDir := t.TempDir()
+	externalDir := t.TempDir()
+
+	// Create an external model to serve as a dependency
+	externalContent := `---
+database: dep_db
+table: dep_table
+cache:
+  incremental_scan_interval: 1m
+  full_scan_interval: 1h
+---
+SELECT * FROM test`
+
+	externalFile := filepath.Join(externalDir, "dependency.sql")
+	err := os.WriteFile(externalFile, []byte(externalContent), 0o644)
+	require.NoError(t, err)
+
+	// Create a transformation model without database field
+	transformationContent := `table: test_table
+interval:
+  max: 100
+  min: 10
+schedules:
+  forwardfill: "0 * * * *"
+dependencies:
+  - dep_db.dep_table
+exec: "echo test"`
+
+	transformationFile := filepath.Join(transformationDir, "test.yml")
+	err = os.WriteFile(transformationFile, []byte(transformationContent), 0o644)
+	require.NoError(t, err)
+
+	log := logrus.New()
+	log.SetLevel(logrus.DebugLevel)
+
+	clickhouseCfg := &clickhouse.Config{
+		URL:         "http://localhost:8123",
+		Cluster:     "test_cluster",
+		LocalSuffix: "_local",
+	}
+
+	tests := []struct {
+		name        string
+		config      *Config
+		shouldError bool
+		errorMsg    string
+	}{
+		{
+			name: "fails when no default database is provided",
+			config: &Config{
+				External: ExternalConfig{
+					Paths:           []string{externalDir},
+					DefaultDatabase: "dep_db",
+				},
+				Transformation: TransformationConfig{
+					Paths:           []string{transformationDir},
+					DefaultDatabase: "", // No default database
+				},
+			},
+			shouldError: true,
+			errorMsg:    "database is required",
+		},
+		{
+			name: "succeeds when default database is provided",
+			config: &Config{
+				External: ExternalConfig{
+					Paths:           []string{externalDir},
+					DefaultDatabase: "dep_db",
+				},
+				Transformation: TransformationConfig{
+					Paths:           []string{transformationDir},
+					DefaultDatabase: "test_db", // Has default database
+				},
+			},
+			shouldError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, err := NewService(log, tt.config, nil, clickhouseCfg)
+			require.NoError(t, err)
+
+			err = svc.Start()
+			if tt.shouldError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/models/template_test.go
+++ b/pkg/models/template_test.go
@@ -27,6 +27,9 @@ func (m *mockTransformationWithTemplate) GetSQL() string                    { re
 func (m *mockTransformationWithTemplate) GetType() string                   { return "transformation" }
 func (m *mockTransformationWithTemplate) GetValue() string                  { return m.value }
 func (m *mockTransformationWithTemplate) GetEnvironmentVariables() []string { return []string{} }
+func (m *mockTransformationWithTemplate) SetDefaultDatabase(defaultDB string) {
+	m.config.SetDefaults(defaultDB)
+}
 
 // Mock external with template value
 type mockExternalWithTemplate struct {
@@ -42,6 +45,9 @@ func (m *mockExternalWithTemplate) GetType() string                   { return m
 func (m *mockExternalWithTemplate) GetSQL() string                    { return "" }
 func (m *mockExternalWithTemplate) GetValue() string                  { return m.value }
 func (m *mockExternalWithTemplate) GetEnvironmentVariables() []string { return []string{} }
+func (m *mockExternalWithTemplate) SetDefaultDatabase(defaultDB string) {
+	m.config.SetDefaults(defaultDB)
+}
 
 // Test NewTemplateEngine
 func TestNewTemplateEngine(t *testing.T) {

--- a/pkg/models/transformation.go
+++ b/pkg/models/transformation.go
@@ -36,6 +36,7 @@ type Transformation interface {
 	GetID() string
 	GetConfig() *transformation.Config
 	GetValue() string
+	SetDefaultDatabase(defaultDB string)
 }
 
 // NewTransformation creates a new transformation model from file content

--- a/pkg/models/transformation/config_test.go
+++ b/pkg/models/transformation/config_test.go
@@ -1,0 +1,261 @@
+package transformation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigSetDefaults(t *testing.T) {
+	tests := []struct {
+		name            string
+		config          *Config
+		defaultDatabase string
+		expectedDB      string
+	}{
+		{
+			name: "apply default when database is empty",
+			config: &Config{
+				Table: "test_table",
+				Interval: &IntervalConfig{
+					Max: 100,
+					Min: 10,
+				},
+				Schedules: &SchedulesConfig{
+					ForwardFill: "0 * * * *",
+				},
+				Dependencies: []string{"dep1"},
+			},
+			defaultDatabase: "default_db",
+			expectedDB:      "default_db",
+		},
+		{
+			name: "keep existing database when already set",
+			config: &Config{
+				Database: "existing_db",
+				Table:    "test_table",
+				Interval: &IntervalConfig{
+					Max: 100,
+					Min: 10,
+				},
+				Schedules: &SchedulesConfig{
+					ForwardFill: "0 * * * *",
+				},
+				Dependencies: []string{"dep1"},
+			},
+			defaultDatabase: "default_db",
+			expectedDB:      "existing_db",
+		},
+		{
+			name: "no change when default is empty",
+			config: &Config{
+				Table: "test_table",
+				Interval: &IntervalConfig{
+					Max: 100,
+					Min: 10,
+				},
+				Schedules: &SchedulesConfig{
+					ForwardFill: "0 * * * *",
+				},
+				Dependencies: []string{"dep1"},
+			},
+			defaultDatabase: "",
+			expectedDB:      "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.config.SetDefaults(tt.defaultDatabase)
+			assert.Equal(t, tt.expectedDB, tt.config.Database)
+		})
+	}
+}
+
+func TestConfigSubstituteDependencyPlaceholders(t *testing.T) {
+	tests := []struct {
+		name                    string
+		config                  *Config
+		externalDefaultDB       string
+		transformationDefaultDB string
+		expectedDependencies    []string
+	}{
+		{
+			name: "substitute external placeholders",
+			config: &Config{
+				Dependencies: []string{
+					"{{external}}.beacon_blocks",
+					"{{external}}.validators",
+					"analytics.hourly_stats",
+				},
+			},
+			externalDefaultDB:       "ethereum",
+			transformationDefaultDB: "analytics",
+			expectedDependencies: []string{
+				"ethereum.beacon_blocks",
+				"ethereum.validators",
+				"analytics.hourly_stats",
+			},
+		},
+		{
+			name: "substitute transformation placeholders",
+			config: &Config{
+				Dependencies: []string{
+					"{{transformation}}.daily_summary",
+					"{{transformation}}.weekly_rollup",
+					"ethereum.blocks",
+				},
+			},
+			externalDefaultDB:       "ethereum",
+			transformationDefaultDB: "analytics",
+			expectedDependencies: []string{
+				"analytics.daily_summary",
+				"analytics.weekly_rollup",
+				"ethereum.blocks",
+			},
+		},
+		{
+			name: "substitute mixed placeholders",
+			config: &Config{
+				Dependencies: []string{
+					"{{external}}.blocks",
+					"{{transformation}}.hourly",
+					"custom.specific_table",
+				},
+			},
+			externalDefaultDB:       "raw_data",
+			transformationDefaultDB: "processed",
+			expectedDependencies: []string{
+				"raw_data.blocks",
+				"processed.hourly",
+				"custom.specific_table",
+			},
+		},
+		{
+			name: "no substitution when defaults are empty",
+			config: &Config{
+				Dependencies: []string{
+					"{{external}}.blocks",
+					"{{transformation}}.hourly",
+				},
+			},
+			externalDefaultDB:       "",
+			transformationDefaultDB: "",
+			expectedDependencies: []string{
+				"{{external}}.blocks",
+				"{{transformation}}.hourly",
+			},
+		},
+		{
+			name: "no placeholders to substitute",
+			config: &Config{
+				Dependencies: []string{
+					"ethereum.blocks",
+					"analytics.hourly",
+				},
+			},
+			externalDefaultDB:       "default_external",
+			transformationDefaultDB: "default_transform",
+			expectedDependencies: []string{
+				"ethereum.blocks",
+				"analytics.hourly",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.config.SubstituteDependencyPlaceholders(tt.externalDefaultDB, tt.transformationDefaultDB)
+			assert.Equal(t, tt.expectedDependencies, tt.config.Dependencies)
+		})
+	}
+}
+
+func TestConfigValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  *Config
+		wantErr bool
+		errMsg  error
+	}{
+		{
+			name: "valid config with all required fields",
+			config: &Config{
+				Database: "test_db",
+				Table:    "test_table",
+				Interval: &IntervalConfig{
+					Max: 100,
+					Min: 10,
+				},
+				Schedules: &SchedulesConfig{
+					ForwardFill: "0 * * * *",
+				},
+				Dependencies: []string{"dep1"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid config without database",
+			config: &Config{
+				Table: "test_table",
+				Interval: &IntervalConfig{
+					Max: 100,
+					Min: 10,
+				},
+				Schedules: &SchedulesConfig{
+					ForwardFill: "0 * * * *",
+				},
+				Dependencies: []string{"dep1"},
+			},
+			wantErr: true,
+			errMsg:  ErrDatabaseRequired,
+		},
+		{
+			name: "invalid config without table",
+			config: &Config{
+				Database: "test_db",
+				Interval: &IntervalConfig{
+					Max: 100,
+					Min: 10,
+				},
+				Schedules: &SchedulesConfig{
+					ForwardFill: "0 * * * *",
+				},
+				Dependencies: []string{"dep1"},
+			},
+			wantErr: true,
+			errMsg:  ErrTableRequired,
+		},
+		{
+			name: "invalid config without dependencies",
+			config: &Config{
+				Database: "test_db",
+				Table:    "test_table",
+				Interval: &IntervalConfig{
+					Max: 100,
+					Min: 10,
+				},
+				Schedules: &SchedulesConfig{
+					ForwardFill: "0 * * * *",
+				},
+				Dependencies: []string{},
+			},
+			wantErr: true,
+			errMsg:  ErrDependenciesRequired,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errMsg != nil {
+					assert.Equal(t, tt.errMsg, err)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/models/transformation/exec.go
+++ b/pkg/models/transformation/exec.go
@@ -31,8 +31,10 @@ func NewTransformationExec(content []byte) (*Exec, error) {
 		return nil, fmt.Errorf("failed to parse yaml: %w", err)
 	}
 
-	if err := config.Validate(); err != nil {
-		return nil, err
+	// Validation is performed after applying defaults in service.go
+	// Only do basic structural validation here
+	if config.Exec == "" {
+		return nil, ErrExecRequired
 	}
 
 	return config, nil
@@ -61,4 +63,9 @@ func (c *Exec) GetConfig() *Config {
 // GetValue returns the exec command
 func (c *Exec) GetValue() string {
 	return c.Exec
+}
+
+// SetDefaultDatabase applies the default database if not already set
+func (c *Exec) SetDefaultDatabase(defaultDB string) {
+	c.SetDefaults(defaultDB)
 }

--- a/pkg/models/transformation/sql.go
+++ b/pkg/models/transformation/sql.go
@@ -43,8 +43,10 @@ func NewTransformationSQL(content []byte) (*SQL, error) {
 
 	config.Content = string(parts[1])
 
-	if err := config.Validate(); err != nil {
-		return nil, err
+	// Validation is performed after applying defaults in service.go
+	// Only do basic structural validation here
+	if config.Content == "" {
+		return nil, ErrSQLContentRequired
 	}
 
 	return config, nil
@@ -73,4 +75,9 @@ func (c *SQL) GetConfig() *Config {
 // GetValue returns the SQL content
 func (c *SQL) GetValue() string {
 	return c.Content
+}
+
+// SetDefaultDatabase applies the default database if not already set
+func (c *SQL) SetDefaultDatabase(defaultDB string) {
+	c.SetDefaults(defaultDB)
 }

--- a/pkg/scheduler/service_test.go
+++ b/pkg/scheduler/service_test.go
@@ -521,5 +521,10 @@ func (m *mockTransformation) GetDependencies() []string         { return m.deps 
 func (m *mockTransformation) GetSQL() string                    { return m.sql }
 func (m *mockTransformation) GetType() string                   { return m.typ }
 func (m *mockTransformation) GetEnvironmentVariables() []string { return []string{} }
+func (m *mockTransformation) SetDefaultDatabase(defaultDB string) {
+	if m.conf.Database == "" {
+		m.conf.Database = defaultDB
+	}
+}
 
 var _ models.Transformation = (*mockTransformation)(nil)

--- a/pkg/validation/external_test.go
+++ b/pkg/validation/external_test.go
@@ -204,6 +204,15 @@ func (a *externalModelAdapter) GetValue() string {
 	return a.testModel.GetValue()
 }
 
+func (a *externalModelAdapter) SetDefaultDatabase(defaultDB string) {
+	// Update the underlying config if needed
+	config := a.testModel.GetConfig()
+	if config.Database == "" {
+		config.Database = defaultDB
+		a.testModel.config = config
+	}
+}
+
 func TestQueryParsing(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/pkg/validation/validator_test.go
+++ b/pkg/validation/validator_test.go
@@ -561,6 +561,9 @@ func (m *mockTransformation) GetDependencies() []string         { return []strin
 func (m *mockTransformation) GetSQL() string                    { return "" }
 func (m *mockTransformation) GetType() string                   { return "transformation" }
 func (m *mockTransformation) GetEnvironmentVariables() []string { return []string{} }
+func (m *mockTransformation) SetDefaultDatabase(_ string) {
+	// No-op for mock
+}
 
 // Test NewDependencyValidator creation
 func TestNewDependencyValidator(t *testing.T) {
@@ -769,6 +772,9 @@ func (m *mockExternal) GetConfig() external.Config {
 }
 func (m *mockExternal) GetValue() string { return "" }
 func (m *mockExternal) GetType() string  { return "sql" }
+func (m *mockExternal) SetDefaultDatabase(_ string) {
+	// No-op for mock
+}
 
 // mockExternalModelValidator is a mock implementation for testing
 type mockExternalModelValidator struct {

--- a/pkg/worker/executor_test.go
+++ b/pkg/worker/executor_test.go
@@ -604,6 +604,11 @@ func (m *mockExecutorTransformation) GetDependencies() []string         { return
 func (m *mockExecutorTransformation) GetSQL() string                    { return m.sql }
 func (m *mockExecutorTransformation) GetType() string                   { return m.typ }
 func (m *mockExecutorTransformation) GetEnvironmentVariables() []string { return []string{} }
+func (m *mockExecutorTransformation) SetDefaultDatabase(defaultDB string) {
+	if m.conf.Database == "" {
+		m.conf.Database = defaultDB
+	}
+}
 
 var _ models.Transformation = (*mockExecutorTransformation)(nil)
 
@@ -620,6 +625,11 @@ func (m *mockExternal) GetID() string              { return m.id }
 func (m *mockExternal) GetConfig() external.Config { return m.conf }
 func (m *mockExternal) GetValue() string           { return m.val }
 func (m *mockExternal) GetType() string            { return m.typ }
+func (m *mockExternal) SetDefaultDatabase(defaultDB string) {
+	if m.conf.Database == "" {
+		m.conf.Database = defaultDB
+	}
+}
 
 var _ models.External = (*mockExternal)(nil)
 

--- a/pkg/worker/service_test.go
+++ b/pkg/worker/service_test.go
@@ -352,6 +352,9 @@ func (m *mockTransformation) GetDependencies() []string         { return []strin
 func (m *mockTransformation) GetSQL() string                    { return "" }
 func (m *mockTransformation) GetType() string                   { return "transformation" }
 func (m *mockTransformation) GetEnvironmentVariables() []string { return []string{} }
+func (m *mockTransformation) SetDefaultDatabase(_ string) {
+	// No-op for mock
+}
 
 var _ models.Transformation = (*mockTransformation)(nil)
 


### PR DESCRIPTION
Support optional defaultDatabase configuration for external and transformation models. Models can omit database field to use defaults, and dependencies can use {{external}} and {{transformation}} placeholders for better portability.