### PR TITLE
feat: add placeholder dependency support for portable SQL templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,12 @@ Models support Go template syntax with the following variables:
 - `{{ .task.start }}` - Task start timestamp
 - `{{ index .dep "db" "table" "field" }}` - Access dependency configuration
 
+When using placeholder dependencies (e.g., `{{external}}.beacon_blocks`), you can access them in templates using either form:
+- **Placeholder form**: `{{ index .dep "{{external}}" "beacon_blocks" "database" }}`
+- **Resolved form**: `{{ index .dep "ethereum" "beacon_blocks" "database" }}`
+
+Both forms work identically, allowing your templates to be portable across different database configurations.
+
 #### Example
 
 ```sql
@@ -287,7 +293,7 @@ SELECT
     count(DISTINCT meta_client_name) as client_count,
     avg(propagation_slot_start_diff) as avg_propagation,
     {{ .bounds.start }} as position
-FROM `{{ index .dep "ethereum" "beacon_blocks" "database" }}`.`{{ index .dep "ethereum" "beacon_blocks" "table" }}`
+FROM `{{ index .dep "{{external}}" "beacon_blocks" "database" }}`.`{{ index .dep "{{external}}" "beacon_blocks" "table" }}`
 WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
 GROUP BY slot_start_date_time, slot, block_root;
 

--- a/example/models/transformations/blocks/block_entity.sql
+++ b/example/models/transformations/blocks/block_entity.sql
@@ -32,7 +32,7 @@ FROM (
         slot,
         block_root,
         validator_index
-    FROM `{{ index .dep "ethereum" "beacon_blocks" "database" }}`.`{{ index .dep "ethereum" "beacon_blocks" "table" }}`
+    FROM `{{ index .dep "{{external}}" "beacon_blocks" "database" }}`.`{{ index .dep "{{external}}" "beacon_blocks" "table" }}`
     WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
 ) b
 -- Always look back 24 hours to get the most recent entity mapping for each validator
@@ -40,7 +40,7 @@ LEFT JOIN (
     SELECT 
         validator_index,
         argMax(entity_name, slot_start_date_time) as entity_name
-    FROM `{{ index .dep "ethereum" "validator_entity" "database" }}`.`{{ index .dep "ethereum" "validator_entity" "table" }}`
+    FROM `{{ index .dep "{{external}}" "validator_entity" "database" }}`.`{{ index .dep "{{external}}" "validator_entity" "table" }}`
     WHERE slot_start_date_time >= fromUnixTimestamp({{ .bounds.start }}) - INTERVAL 24 HOUR
       AND slot_start_date_time <= fromUnixTimestamp({{ .bounds.end }})
     GROUP BY validator_index

--- a/example/models/transformations/blocks/block_propagation.sql
+++ b/example/models/transformations/blocks/block_propagation.sql
@@ -29,7 +29,7 @@ SELECT
     min(propagation_slot_start_diff) as min_propagation,
     max(propagation_slot_start_diff) as max_propagation,
     {{ .bounds.start }} as position
-FROM `{{ index .dep "ethereum" "beacon_blocks" "database" }}`.`{{ index .dep "ethereum" "beacon_blocks" "table" }}`
+FROM `{{ index .dep "{{external}}" "beacon_blocks" "database" }}`.`{{ index .dep "{{external}}" "beacon_blocks" "table" }}`
 WHERE slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
 GROUP BY slot_start_date_time, slot, block_root;
 

--- a/example/models/transformations/blocks/block_stats.sql
+++ b/example/models/transformations/blocks/block_stats.sql
@@ -30,7 +30,7 @@ SELECT
     count(DISTINCT entity_name) as max_entities,  -- Same for now
     count(DISTINCT entity_name) as min_entities,   -- Same for now
     {{ .bounds.start }} as position
-FROM `{{ index .dep "analytics" "block_entity" "database" }}`.`{{ index .dep "analytics" "block_entity" "table" }}`
+FROM `{{ index .dep "{{transformation}}" "block_entity" "database" }}`.`{{ index .dep "{{transformation}}" "block_entity" "table" }}`
 WHERE slot_start_date_time >= fromUnixTimestamp({{ .bounds.start }})
   AND slot_start_date_time < fromUnixTimestamp({{ .bounds.end }})
 GROUP BY hour_start;

--- a/example/models/transformations/entities/entity_network_effects.sql
+++ b/example/models/transformations/entities/entity_network_effects.sql
@@ -39,7 +39,7 @@ SELECT
     -- Interval tracking
     {{ .self.interval }} as interval
     
-FROM `{{ index .dep "analytics" "block_entity" "database" }}`.`{{ index .dep "analytics" "block_entity" "table" }}` be
+FROM `{{ index .dep "{{transformation}}" "block_entity" "database" }}`.`{{ index .dep "{{transformation}}" "block_entity" "table" }}` be
 INNER JOIN `{{ index .dep "analytics" "block_propagation" "database" }}`.`{{ index .dep "analytics" "block_propagation" "table" }}` bp
     ON be.slot = bp.slot 
     AND be.block_root = bp.block_root

--- a/pkg/models/transformation/config.go
+++ b/pkg/models/transformation/config.go
@@ -36,6 +36,10 @@ type Config struct {
 	Schedules    *SchedulesConfig `yaml:"schedules"`
 	Dependencies []string         `yaml:"dependencies"`
 	Tags         []string         `yaml:"tags"`
+
+	// OriginalDependencies stores the dependencies before placeholder substitution
+	// This is used by the template engine to create dual entries
+	OriginalDependencies []string `yaml:"-"`
 }
 
 // IntervalConfig defines interval configuration for transformations
@@ -108,6 +112,10 @@ func (c *Config) SetDefaults(defaultDatabase string) {
 // SubstituteDependencyPlaceholders replaces {{external}} and {{transformation}} placeholders
 // with the actual default database names
 func (c *Config) SubstituteDependencyPlaceholders(externalDefaultDB, transformationDefaultDB string) {
+	// Save original dependencies before substitution
+	c.OriginalDependencies = make([]string, len(c.Dependencies))
+	copy(c.OriginalDependencies, c.Dependencies)
+
 	for i, dep := range c.Dependencies {
 		if externalDefaultDB != "" {
 			c.Dependencies[i] = strings.ReplaceAll(dep, "{{external}}", externalDefaultDB)


### PR DESCRIPTION
- Update SQL templates to use {{external}} and {{transformation}} placeholders
- Enhance template engine to support both placeholder and resolved dependency access
- Add dual key access allowing templates to work with either form
- Store original dependencies to maintain placeholder references
- Add comprehensive tests for dual key dependency access
- Update documentation with examples of placeholder usage

This allows SQL templates to be portable across different database configurations while maintaining backward compatibility with direct database references.