### PR TITLE
chore(docker-compose): add linux/amd64 platform for asynqmon and redis-commander 

### DIFF
--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   # ClickHouse database
   clickhouse:
-    image: clickhouse/clickhouse-server:latest
+    image: "clickhouse/clickhouse-server:${CHVER:-latest}"
     container_name: cbt-clickhouse
     ports:
       - "8123:8123"  # HTTP interface
@@ -134,6 +134,7 @@ services:
   # Asynq monitoring UI for task queue visibility
   asynqmon:
     image: hibiken/asynqmon:latest
+    platform: linux/amd64
     container_name: cbt-asynqmon
     ports:
       - "8080:8080"
@@ -148,6 +149,7 @@ services:
   # Redis Commander for Redis management
   redis-commander:
     image: rediscommander/redis-commander:latest
+    platform: linux/amd64
     container_name: cbt-redis-commander
     ports:
       - "8081:8081"


### PR DESCRIPTION
- Pin ClickHouse version via `CHVER` env var (optional)
- Add `platform: linux/amd64` to `asynqmon` and `redis-commander` services to enable x86_64 emulation on Apple Silicon Macs. These images don't have native ARM64 builds, causing "no matching manifest" errors.