### PR TITLE
feat: implement Boolean OR dependencies for flexible data validation

### DIFF
--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   # ClickHouse database
   clickhouse:
-    image: "clickhouse/clickhouse-server:${CHVER:-latest}"
+    image: "clickhouse/clickhouse-server:${CHVER:-25.5.10}"
     container_name: cbt-clickhouse
     ports:
       - "8123:8123"  # HTTP interface

--- a/example/init-clickhouse/02_create_example_tables.sql
+++ b/example/init-clickhouse/02_create_example_tables.sql
@@ -133,4 +133,44 @@ PARTITION BY toYYYYMM(hour_start)
 ORDER BY (hour_start, position)
 ;
 
+-- Create entity_network_effects_or_test table (OR dependency test)
+CREATE TABLE IF NOT EXISTS analytics.entity_network_effects_or_test
+(
+    updated_date_time DateTime DEFAULT now() CODEC(DoubleDelta, ZSTD(1)),
+    event_date_time DateTime64(3) DEFAULT now64(3) CODEC(DoubleDelta, ZSTD(1)),
+    slot_start_date_time DateTime,
+    
+    -- Entity identifier
+    entity_name String,
+    
+    -- Aggregated metrics for this entity in this interval
+    blocks_in_window UInt32,
+    entity_avg_propagation Float32,
+    entity_median_propagation Float32,
+    entity_min_propagation Float32,
+    entity_max_propagation Float32,
+    entity_propagation_stddev Float32,
+    
+    -- Interval tracking
+    interval UInt64 DEFAULT 0
+)
+ENGINE = ReplacingMergeTree(updated_date_time)
+PARTITION BY toYYYYMM(slot_start_date_time)
+ORDER BY (slot_start_date_time, entity_name, interval)
+;
+
+-- Create block_never_loads table (test transformation that never loads)
+CREATE TABLE IF NOT EXISTS analytics.block_never_loads
+(
+    updated_date_time DateTime DEFAULT now() CODEC(DoubleDelta, ZSTD(1)),
+    event_date_time DateTime64(3) DEFAULT now64(3) CODEC(DoubleDelta, ZSTD(1)),
+    slot_start_date_time DateTime,
+    slot UInt64,
+    position UInt64 DEFAULT 0
+)
+ENGINE = ReplacingMergeTree(updated_date_time)
+PARTITION BY toYYYYMM(slot_start_date_time)
+ORDER BY (slot_start_date_time, slot, position)
+;
+
 -- No initial data - the data generator will create all sample data

--- a/example/models/transformations/blocks/block_never_loads.sql
+++ b/example/models/transformations/blocks/block_never_loads.sql
@@ -1,0 +1,39 @@
+---
+database: analytics
+table: block_never_loads
+interval:
+  max: 3600
+  min: 300
+schedules:
+  forwardfill: "@every 9999h"
+  backfill: "@every 9999h"
+tags:
+  - test
+  - never-loads
+dependencies:
+  - "{{external}}.beacon_blocks"
+---
+-- This transformation will never load data due to schedules
+
+INSERT INTO `{{ .self.database }}`.`{{ .self.table }}`
+SELECT 
+    fromUnixTimestamp({{ .task.start }}) as updated_date_time,
+    now64(3) as event_date_time,
+    slot_start_date_time,
+    slot,
+    {{ .bounds.start }} as position
+FROM `{{ index .dep "ethereum" "beacon_blocks" "database" }}`.`{{ index .dep "ethereum" "beacon_blocks" "table" }}`
+WHERE slot_start_date_time >= fromUnixTimestamp({{ .bounds.start }})
+  AND slot_start_date_time < fromUnixTimestamp({{ .bounds.end }})
+  -- Additional impossible condition to ensure no data loads
+  AND 1 = 0;
+
+-- Clean up (will never execute due to no data being inserted)
+DELETE FROM
+  `{{ .self.database }}`.`{{ .self.table }}{{ if .clickhouse.cluster }}{{ .clickhouse.local_suffix }}{{ end }}`
+{{ if .clickhouse.cluster }}
+  ON CLUSTER '{{ .clickhouse.cluster }}'
+{{ end }}
+WHERE
+  slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
+  AND updated_date_time != fromUnixTimestamp({{ .task.start }});

--- a/example/models/transformations/entities/entity_network_effects_or_test.sql
+++ b/example/models/transformations/entities/entity_network_effects_or_test.sql
@@ -1,0 +1,60 @@
+---
+# database is set in the config models.transformations.defaultDatabase
+# database: analytics
+table: entity_network_effects_or_test
+interval:
+  max: 300
+  min: 0  # Allow any size partial intervals
+schedules:
+  forwardfill: "@every 30s"
+  backfill: "@every 30s"
+tags:
+  - aggregation
+  - entity
+  - network
+  - or-test
+dependencies:
+  # you can use the models.transformations.defaultDatabase template variable here
+  - "{{transformation}}.block_entity"
+  # OR group: block_never_loads (always empty), falls back to block_propagation
+  - ["analytics.block_never_loads", "analytics.block_propagation"]
+---
+INSERT INTO
+  `{{ .self.database }}`.`{{ .self.table }}`
+SELECT 
+    fromUnixTimestamp({{ .task.start }}) as updated_date_time,
+    now64(3) as event_date_time,
+    fromUnixTimestamp({{ .bounds.start }}) as slot_start_date_time,
+    
+    -- Entity identifier
+    be.entity_name,
+    
+    -- Aggregated metrics for this entity in this interval
+    count() as blocks_in_window,
+    avg(bp.avg_propagation) as entity_avg_propagation,
+    median(bp.avg_propagation) as entity_median_propagation,
+    min(bp.avg_propagation) as entity_min_propagation,
+    max(bp.avg_propagation) as entity_max_propagation,
+    stddevPop(bp.avg_propagation) as entity_propagation_stddev,
+    
+    -- Interval tracking
+    {{ .self.interval }} as interval
+    
+FROM `{{ index .dep "{{transformation}}" "block_entity" "database" }}`.`{{ index .dep "{{transformation}}" "block_entity" "table" }}` be
+INNER JOIN `{{ index .dep "analytics" "block_propagation" "database" }}`.`{{ index .dep "analytics" "block_propagation" "table" }}` bp
+    ON be.slot = bp.slot 
+    AND be.block_root = bp.block_root
+WHERE be.slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
+  AND bp.slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
+GROUP BY be.entity_name
+HAVING blocks_in_window > 0;
+
+-- Delete old rows
+DELETE FROM
+  `{{ .self.database }}`.`{{ .self.table }}{{ if .clickhouse.cluster }}{{ .clickhouse.local_suffix }}{{ end }}`
+{{ if .clickhouse.cluster }}
+  ON CLUSTER '{{ .clickhouse.cluster }}'
+{{ end }}
+WHERE
+  slot_start_date_time BETWEEN fromUnixTimestamp({{ .bounds.start }}) AND fromUnixTimestamp({{ .bounds.end }})
+  AND updated_date_time != fromUnixTimestamp({{ .task.start }});

--- a/pkg/coordinator/service_test.go
+++ b/pkg/coordinator/service_test.go
@@ -277,7 +277,7 @@ func (m *mockTransformation) GetConfig() *transformation.Config {
 		Schedules: &transformation.SchedulesConfig{
 			ForwardFill: "@every 1m",
 		},
-		Dependencies: []string{},
+		Dependencies: []transformation.Dependency{},
 	}
 }
 func (m *mockTransformation) GetValue() string                  { return "" }
@@ -403,7 +403,9 @@ func TestAdjustIntervalForDependencies(t *testing.T) {
 					Schedules: &transformation.SchedulesConfig{
 						ForwardFill: "@every 1m",
 					},
-					Dependencies: []string{"dep1"},
+					Dependencies: []transformation.Dependency{
+						{IsGroup: false, SingleDep: "dep1"},
+					},
 				},
 			}
 

--- a/pkg/models/dag.go
+++ b/pkg/models/dag.go
@@ -147,7 +147,10 @@ func (d *DependencyGraph) AddExternalModels(models []External) error {
 func (d *DependencyGraph) AddTransformationEdges(models []Transformation) error {
 	for _, model := range models {
 		if model != nil {
-			for _, depID := range model.GetConfig().Dependencies {
+			config := model.GetConfig()
+			// Process all dependencies (both single and OR groups)
+			allDeps := config.GetFlattenedDependencies()
+			for _, depID := range allDeps {
 				// Validate dependency exists
 				if _, err := d.dag.GetVertex(depID); err != nil {
 					return fmt.Errorf("%w: %s depends on %s", ErrNonExistentDependency, model.GetID(), depID)
@@ -242,6 +245,7 @@ func (d *DependencyGraph) GetDependents(modelID string) []string {
 }
 
 // GetDependencies returns the direct dependencies of a model
+// Note: This returns all dependencies flattened (including those in OR groups)
 func (d *DependencyGraph) GetDependencies(modelID string) []string {
 	d.mutex.RLock()
 	defer d.mutex.RUnlock()

--- a/pkg/models/dag_test.go
+++ b/pkg/models/dag_test.go
@@ -17,6 +17,18 @@ type mockTransformation struct {
 	config       transformation.Config
 }
 
+// Helper function to create dependencies from strings
+func createDependencies(deps []string) []transformation.Dependency {
+	result := make([]transformation.Dependency, len(deps))
+	for i, dep := range deps {
+		result[i] = transformation.Dependency{
+			IsGroup:   false,
+			SingleDep: dep,
+		}
+	}
+	return result
+}
+
 func (m *mockTransformation) GetID() string                       { return m.id }
 func (m *mockTransformation) GetDependencies() []string           { return m.dependencies }
 func (m *mockTransformation) GetConfig() *transformation.Config   { return &m.config }
@@ -64,12 +76,12 @@ func TestBuildGraph(t *testing.T) {
 				&mockTransformation{
 					id:           "trans1",
 					dependencies: []string{},
-					config:       transformation.Config{Dependencies: []string{}},
+					config:       transformation.Config{Dependencies: createDependencies([]string{})},
 				},
 				&mockTransformation{
 					id:           "trans2",
 					dependencies: []string{"trans1"},
-					config:       transformation.Config{Dependencies: []string{"trans1"}},
+					config:       transformation.Config{Dependencies: createDependencies([]string{"trans1"})},
 				},
 			},
 			externals: []External{
@@ -84,12 +96,12 @@ func TestBuildGraph(t *testing.T) {
 				&mockTransformation{
 					id:           "trans1",
 					dependencies: []string{"trans2"},
-					config:       transformation.Config{Dependencies: []string{"trans2"}},
+					config:       transformation.Config{Dependencies: createDependencies([]string{"trans2"})},
 				},
 				&mockTransformation{
 					id:           "trans2",
 					dependencies: []string{"trans1"},
-					config:       transformation.Config{Dependencies: []string{"trans1"}},
+					config:       transformation.Config{Dependencies: createDependencies([]string{"trans1"})},
 				},
 			},
 			externals: []External{},
@@ -276,17 +288,17 @@ func TestGetDependenciesAndDependents(t *testing.T) {
 	trans1 := &mockTransformation{
 		id:           "trans1",
 		dependencies: []string{},
-		config:       transformation.Config{Dependencies: []string{}},
+		config:       transformation.Config{Dependencies: createDependencies([]string{})},
 	}
 	trans2 := &mockTransformation{
 		id:           "trans2",
 		dependencies: []string{"trans1"},
-		config:       transformation.Config{Dependencies: []string{"trans1"}},
+		config:       transformation.Config{Dependencies: createDependencies([]string{"trans1"})},
 	}
 	trans3 := &mockTransformation{
 		id:           "trans3",
 		dependencies: []string{"trans1", "trans2"},
-		config:       transformation.Config{Dependencies: []string{"trans1", "trans2"}},
+		config:       transformation.Config{Dependencies: createDependencies([]string{"trans1", "trans2"})},
 	}
 
 	err := dg.BuildGraph([]Transformation{trans1, trans2, trans3}, []External{})
@@ -332,22 +344,22 @@ func TestGetAllDependenciesAndDependents(t *testing.T) {
 	trans1 := &mockTransformation{
 		id:           "trans1",
 		dependencies: []string{},
-		config:       transformation.Config{Dependencies: []string{}},
+		config:       transformation.Config{Dependencies: createDependencies([]string{})},
 	}
 	trans2 := &mockTransformation{
 		id:           "trans2",
 		dependencies: []string{"trans1"},
-		config:       transformation.Config{Dependencies: []string{"trans1"}},
+		config:       transformation.Config{Dependencies: createDependencies([]string{"trans1"})},
 	}
 	trans3 := &mockTransformation{
 		id:           "trans3",
 		dependencies: []string{"trans1"},
-		config:       transformation.Config{Dependencies: []string{"trans1"}},
+		config:       transformation.Config{Dependencies: createDependencies([]string{"trans1"})},
 	}
 	trans4 := &mockTransformation{
 		id:           "trans4",
 		dependencies: []string{"trans2", "trans3"},
-		config:       transformation.Config{Dependencies: []string{"trans2", "trans3"}},
+		config:       transformation.Config{Dependencies: createDependencies([]string{"trans2", "trans3"})},
 	}
 
 	err := dg.BuildGraph([]Transformation{trans1, trans2, trans3, trans4}, []External{})
@@ -375,12 +387,12 @@ func TestGetTransformationNodes(t *testing.T) {
 
 	trans1 := &mockTransformation{
 		id:     "trans1",
-		config: transformation.Config{Dependencies: []string{}},
+		config: transformation.Config{Dependencies: createDependencies([]string{})},
 	}
 	trans2 := &mockTransformation{
 		id:           "trans2",
 		dependencies: []string{"trans1"},
-		config:       transformation.Config{Dependencies: []string{"trans1"}},
+		config:       transformation.Config{Dependencies: createDependencies([]string{"trans1"})},
 	}
 	ext := &mockExternal{id: "ext1", typ: external.ExternalTypeSQL}
 
@@ -403,21 +415,21 @@ func TestIsPathBetween(t *testing.T) {
 
 	trans1 := &mockTransformation{
 		id:     "trans1",
-		config: transformation.Config{Dependencies: []string{}},
+		config: transformation.Config{Dependencies: createDependencies([]string{})},
 	}
 	trans2 := &mockTransformation{
 		id:           "trans2",
 		dependencies: []string{"trans1"},
-		config:       transformation.Config{Dependencies: []string{"trans1"}},
+		config:       transformation.Config{Dependencies: createDependencies([]string{"trans1"})},
 	}
 	trans3 := &mockTransformation{
 		id:           "trans3",
 		dependencies: []string{"trans2"},
-		config:       transformation.Config{Dependencies: []string{"trans2"}},
+		config:       transformation.Config{Dependencies: createDependencies([]string{"trans2"})},
 	}
 	trans4 := &mockTransformation{
 		id:     "trans4",
-		config: transformation.Config{Dependencies: []string{}},
+		config: transformation.Config{Dependencies: createDependencies([]string{})},
 	}
 
 	err := dg.BuildGraph([]Transformation{trans1, trans2, trans3, trans4}, []External{})
@@ -475,12 +487,12 @@ func TestConcurrentAccess(t *testing.T) {
 
 	trans1 := &mockTransformation{
 		id:     "trans1",
-		config: transformation.Config{Dependencies: []string{}},
+		config: transformation.Config{Dependencies: createDependencies([]string{})},
 	}
 	trans2 := &mockTransformation{
 		id:           "trans2",
 		dependencies: []string{"trans1"},
-		config:       transformation.Config{Dependencies: []string{"trans1"}},
+		config:       transformation.Config{Dependencies: createDependencies([]string{"trans1"})},
 	}
 
 	err := dg.BuildGraph([]Transformation{trans1, trans2}, []External{})
@@ -517,7 +529,7 @@ func BenchmarkBuildGraph(b *testing.B) {
 		transformations[i] = &mockTransformation{
 			id:           string(rune(i)),
 			dependencies: deps,
-			config:       transformation.Config{Dependencies: deps},
+			config:       transformation.Config{Dependencies: createDependencies(deps)},
 		}
 	}
 
@@ -541,7 +553,7 @@ func BenchmarkGetAllDependencies(b *testing.B) {
 		transformations[i] = &mockTransformation{
 			id:           string(rune(i)),
 			dependencies: deps,
-			config:       transformation.Config{Dependencies: deps},
+			config:       transformation.Config{Dependencies: createDependencies(deps)},
 		}
 	}
 

--- a/pkg/models/service_test.go
+++ b/pkg/models/service_test.go
@@ -237,18 +237,27 @@ exec: "echo test"`
 		cfg := model.GetConfig()
 		for _, dep := range cfg.Dependencies {
 			// Should not contain any placeholders
-			assert.NotContains(t, dep, "{{external}}")
-			assert.NotContains(t, dep, "{{transformation}}")
+			if dep.IsGroup {
+				for _, groupDep := range dep.GroupDeps {
+					assert.NotContains(t, groupDep, "{{external}}")
+					assert.NotContains(t, groupDep, "{{transformation}}")
+				}
+			} else {
+				assert.NotContains(t, dep.SingleDep, "{{external}}")
+				assert.NotContains(t, dep.SingleDep, "{{transformation}}")
+			}
+		}
 
-			// Check specific substitutions
-			if cfg.Table == "test_transform" {
-				assert.Contains(t, cfg.Dependencies, "ethereum.beacon_blocks")
-				assert.Contains(t, cfg.Dependencies, "analytics.other_transform")
-				assert.Contains(t, cfg.Dependencies, "custom_db.custom_table")
-			}
-			if cfg.Table == "other_transform" {
-				assert.Contains(t, cfg.Dependencies, "ethereum.beacon_blocks")
-			}
+		// Check specific substitutions by getting flattened dependencies
+		if cfg.Table == "test_transform" {
+			flatDeps := cfg.GetFlattenedDependencies()
+			assert.Contains(t, flatDeps, "ethereum.beacon_blocks")
+			assert.Contains(t, flatDeps, "analytics.other_transform")
+			assert.Contains(t, flatDeps, "custom_db.custom_table")
+		}
+		if cfg.Table == "other_transform" {
+			flatDeps := cfg.GetFlattenedDependencies()
+			assert.Contains(t, flatDeps, "ethereum.beacon_blocks")
 		}
 	}
 }

--- a/pkg/models/transformation/config_test.go
+++ b/pkg/models/transformation/config_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestConfigSetDefaults(t *testing.T) {
@@ -24,7 +26,7 @@ func TestConfigSetDefaults(t *testing.T) {
 				Schedules: &SchedulesConfig{
 					ForwardFill: "0 * * * *",
 				},
-				Dependencies: []string{"dep1"},
+				Dependencies: []Dependency{{IsGroup: false, SingleDep: "dep1"}},
 			},
 			defaultDatabase: "default_db",
 			expectedDB:      "default_db",
@@ -41,7 +43,7 @@ func TestConfigSetDefaults(t *testing.T) {
 				Schedules: &SchedulesConfig{
 					ForwardFill: "0 * * * *",
 				},
-				Dependencies: []string{"dep1"},
+				Dependencies: []Dependency{{IsGroup: false, SingleDep: "dep1"}},
 			},
 			defaultDatabase: "default_db",
 			expectedDB:      "existing_db",
@@ -57,7 +59,7 @@ func TestConfigSetDefaults(t *testing.T) {
 				Schedules: &SchedulesConfig{
 					ForwardFill: "0 * * * *",
 				},
-				Dependencies: []string{"dep1"},
+				Dependencies: []Dependency{{IsGroup: false, SingleDep: "dep1"}},
 			},
 			defaultDatabase: "",
 			expectedDB:      "",
@@ -83,10 +85,10 @@ func TestConfigSubstituteDependencyPlaceholders(t *testing.T) {
 		{
 			name: "substitute external placeholders",
 			config: &Config{
-				Dependencies: []string{
-					"{{external}}.beacon_blocks",
-					"{{external}}.validators",
-					"analytics.hourly_stats",
+				Dependencies: []Dependency{
+					{IsGroup: false, SingleDep: "{{external}}.beacon_blocks"},
+					{IsGroup: false, SingleDep: "{{external}}.validators"},
+					{IsGroup: false, SingleDep: "analytics.hourly_stats"},
 				},
 			},
 			externalDefaultDB:       "ethereum",
@@ -100,10 +102,10 @@ func TestConfigSubstituteDependencyPlaceholders(t *testing.T) {
 		{
 			name: "substitute transformation placeholders",
 			config: &Config{
-				Dependencies: []string{
-					"{{transformation}}.daily_summary",
-					"{{transformation}}.weekly_rollup",
-					"ethereum.blocks",
+				Dependencies: []Dependency{
+					{IsGroup: false, SingleDep: "{{transformation}}.daily_summary"},
+					{IsGroup: false, SingleDep: "{{transformation}}.weekly_rollup"},
+					{IsGroup: false, SingleDep: "ethereum.blocks"},
 				},
 			},
 			externalDefaultDB:       "ethereum",
@@ -117,10 +119,10 @@ func TestConfigSubstituteDependencyPlaceholders(t *testing.T) {
 		{
 			name: "substitute mixed placeholders",
 			config: &Config{
-				Dependencies: []string{
-					"{{external}}.blocks",
-					"{{transformation}}.hourly",
-					"custom.specific_table",
+				Dependencies: []Dependency{
+					{IsGroup: false, SingleDep: "{{external}}.blocks"},
+					{IsGroup: false, SingleDep: "{{transformation}}.hourly"},
+					{IsGroup: false, SingleDep: "custom.specific_table"},
 				},
 			},
 			externalDefaultDB:       "raw_data",
@@ -134,9 +136,9 @@ func TestConfigSubstituteDependencyPlaceholders(t *testing.T) {
 		{
 			name: "no substitution when defaults are empty",
 			config: &Config{
-				Dependencies: []string{
-					"{{external}}.blocks",
-					"{{transformation}}.hourly",
+				Dependencies: []Dependency{
+					{IsGroup: false, SingleDep: "{{external}}.blocks"},
+					{IsGroup: false, SingleDep: "{{transformation}}.hourly"},
 				},
 			},
 			externalDefaultDB:       "",
@@ -149,9 +151,9 @@ func TestConfigSubstituteDependencyPlaceholders(t *testing.T) {
 		{
 			name: "no placeholders to substitute",
 			config: &Config{
-				Dependencies: []string{
-					"ethereum.blocks",
-					"analytics.hourly",
+				Dependencies: []Dependency{
+					{IsGroup: false, SingleDep: "ethereum.blocks"},
+					{IsGroup: false, SingleDep: "analytics.hourly"},
 				},
 			},
 			externalDefaultDB:       "default_external",
@@ -166,7 +168,12 @@ func TestConfigSubstituteDependencyPlaceholders(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.config.SubstituteDependencyPlaceholders(tt.externalDefaultDB, tt.transformationDefaultDB)
-			assert.Equal(t, tt.expectedDependencies, tt.config.Dependencies)
+			// Verify that the actual dependencies are transformed correctly
+			for i, dep := range tt.config.Dependencies {
+				if !dep.IsGroup {
+					assert.Equal(t, tt.expectedDependencies[i], dep.SingleDep)
+				}
+			}
 		})
 	}
 }
@@ -190,7 +197,7 @@ func TestConfigValidate(t *testing.T) {
 				Schedules: &SchedulesConfig{
 					ForwardFill: "0 * * * *",
 				},
-				Dependencies: []string{"dep1"},
+				Dependencies: []Dependency{{IsGroup: false, SingleDep: "dep1"}},
 			},
 			wantErr: false,
 		},
@@ -205,7 +212,7 @@ func TestConfigValidate(t *testing.T) {
 				Schedules: &SchedulesConfig{
 					ForwardFill: "0 * * * *",
 				},
-				Dependencies: []string{"dep1"},
+				Dependencies: []Dependency{{IsGroup: false, SingleDep: "dep1"}},
 			},
 			wantErr: true,
 			errMsg:  ErrDatabaseRequired,
@@ -221,7 +228,7 @@ func TestConfigValidate(t *testing.T) {
 				Schedules: &SchedulesConfig{
 					ForwardFill: "0 * * * *",
 				},
-				Dependencies: []string{"dep1"},
+				Dependencies: []Dependency{{IsGroup: false, SingleDep: "dep1"}},
 			},
 			wantErr: true,
 			errMsg:  ErrTableRequired,
@@ -238,7 +245,7 @@ func TestConfigValidate(t *testing.T) {
 				Schedules: &SchedulesConfig{
 					ForwardFill: "0 * * * *",
 				},
-				Dependencies: []string{},
+				Dependencies: []Dependency{},
 			},
 			wantErr: true,
 			errMsg:  ErrDependenciesRequired,
@@ -258,4 +265,219 @@ func TestConfigValidate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDependencyUnmarshalYAML(t *testing.T) {
+	tests := []struct {
+		name     string
+		yaml     string
+		expected Dependency
+		wantErr  bool
+	}{
+		{
+			name: "single string dependency",
+			yaml: `"ethereum.blocks"`,
+			expected: Dependency{
+				IsGroup:   false,
+				SingleDep: "ethereum.blocks",
+			},
+			wantErr: false,
+		},
+		{
+			name: "OR group dependency",
+			yaml: `["ethereum.blocks", "ethereum.blocks_v2"]`,
+			expected: Dependency{
+				IsGroup:   true,
+				GroupDeps: []string{"ethereum.blocks", "ethereum.blocks_v2"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "OR group with multiple items",
+			yaml: `["source1.data", "source2.data", "source3.data"]`,
+			expected: Dependency{
+				IsGroup:   true,
+				GroupDeps: []string{"source1.data", "source2.data", "source3.data"},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "empty OR group",
+			yaml:    `[]`,
+			wantErr: true,
+		},
+		{
+			name:    "invalid type - number",
+			yaml:    `123`,
+			wantErr: true,
+		},
+		{
+			name:    "invalid type - object",
+			yaml:    `{key: value}`,
+			wantErr: true,
+		},
+		{
+			name:    "invalid array element",
+			yaml:    `["valid", 123]`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var dep Dependency
+			err := yaml.Unmarshal([]byte(tt.yaml), &dep)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, dep)
+			}
+		})
+	}
+}
+
+func TestDependencyMarshalYAML(t *testing.T) {
+	tests := []struct {
+		name     string
+		dep      Dependency
+		expected string
+	}{
+		{
+			name: "single dependency",
+			dep: Dependency{
+				IsGroup:   false,
+				SingleDep: "ethereum.blocks",
+			},
+			expected: "ethereum.blocks\n",
+		},
+		{
+			name: "OR group",
+			dep: Dependency{
+				IsGroup:   true,
+				GroupDeps: []string{"source1.data", "source2.data"},
+			},
+			expected: "- source1.data\n- source2.data\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := yaml.Marshal(&tt.dep)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, string(data))
+		})
+	}
+}
+
+func TestDependencyGetAllDependencies(t *testing.T) {
+	tests := []struct {
+		name     string
+		dep      Dependency
+		expected []string
+	}{
+		{
+			name: "single dependency",
+			dep: Dependency{
+				IsGroup:   false,
+				SingleDep: "ethereum.blocks",
+			},
+			expected: []string{"ethereum.blocks"},
+		},
+		{
+			name: "OR group",
+			dep: Dependency{
+				IsGroup:   true,
+				GroupDeps: []string{"source1.data", "source2.data", "source3.data"},
+			},
+			expected: []string{"source1.data", "source2.data", "source3.data"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.dep.GetAllDependencies()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestConfigWithMixedDependencies(t *testing.T) {
+	yamlContent := `
+database: analytics
+table: combined_data
+interval:
+  max: 3600
+  min: 0
+schedules:
+  forwardfill: "@every 1m"
+dependencies:
+  - ethereum.blocks                              # Single dependency (AND)
+  - ["source1.data", "source2.data"]            # OR group
+  - analytics.preprocessed                       # Single dependency (AND)
+  - ["backup1.blocks", "backup2.blocks", "backup3.blocks"]  # OR group
+`
+
+	var config Config
+	err := yaml.Unmarshal([]byte(yamlContent), &config)
+	require.NoError(t, err)
+
+	// Validate the config
+	err = config.Validate()
+	require.NoError(t, err)
+
+	// Check that dependencies were parsed correctly
+	assert.Len(t, config.Dependencies, 4)
+
+	// First dependency - single
+	assert.False(t, config.Dependencies[0].IsGroup)
+	assert.Equal(t, "ethereum.blocks", config.Dependencies[0].SingleDep)
+
+	// Second dependency - OR group
+	assert.True(t, config.Dependencies[1].IsGroup)
+	assert.Equal(t, []string{"source1.data", "source2.data"}, config.Dependencies[1].GroupDeps)
+
+	// Third dependency - single
+	assert.False(t, config.Dependencies[2].IsGroup)
+	assert.Equal(t, "analytics.preprocessed", config.Dependencies[2].SingleDep)
+
+	// Fourth dependency - OR group
+	assert.True(t, config.Dependencies[3].IsGroup)
+	assert.Equal(t, []string{"backup1.blocks", "backup2.blocks", "backup3.blocks"}, config.Dependencies[3].GroupDeps)
+
+	// Test GetFlattenedDependencies
+	flattened := config.GetFlattenedDependencies()
+	expected := []string{
+		"ethereum.blocks",
+		"source1.data", "source2.data",
+		"analytics.preprocessed",
+		"backup1.blocks", "backup2.blocks", "backup3.blocks",
+	}
+	assert.Equal(t, expected, flattened)
+}
+
+func TestConfigSubstitutionWithORGroups(t *testing.T) {
+	config := &Config{
+		Database: "analytics",
+		Table:    "test",
+		Dependencies: []Dependency{
+			{IsGroup: false, SingleDep: "{{external}}.blocks"},
+			{IsGroup: true, GroupDeps: []string{"{{external}}.source1", "{{transformation}}.processed"}},
+			{IsGroup: false, SingleDep: "{{transformation}}.aggregated"},
+		},
+	}
+
+	config.SubstituteDependencyPlaceholders("raw_data", "processed_data")
+
+	// Check single dependencies
+	assert.Equal(t, "raw_data.blocks", config.Dependencies[0].SingleDep)
+	assert.Equal(t, "processed_data.aggregated", config.Dependencies[2].SingleDep)
+
+	// Check OR group
+	assert.Equal(t, []string{"raw_data.source1", "processed_data.processed"}, config.Dependencies[1].GroupDeps)
+
+	// Verify originals are saved
+	assert.Equal(t, "{{external}}.blocks", config.OriginalDependencies[0].SingleDep)
+	assert.Equal(t, []string{"{{external}}.source1", "{{transformation}}.processed"}, config.OriginalDependencies[1].GroupDeps)
 }

--- a/pkg/scheduler/service_test.go
+++ b/pkg/scheduler/service_test.go
@@ -294,7 +294,7 @@ func TestHandleScheduledBackfill(t *testing.T) {
 								ForwardFill: "@every 1m",
 								Backfill:    "*/5 * * * *",
 							},
-							Dependencies: []string{},
+							Dependencies: []transformation.Dependency{},
 						},
 					},
 				}

--- a/pkg/worker/service_test.go
+++ b/pkg/worker/service_test.go
@@ -344,7 +344,7 @@ func (m *mockTransformation) GetConfig() *transformation.Config {
 			ForwardFill: "@every 1m",
 		},
 		Tags:         m.tags,
-		Dependencies: []string{},
+		Dependencies: []transformation.Dependency{},
 	}
 }
 func (m *mockTransformation) GetValue() string                  { return "" }


### PR DESCRIPTION
Adds support for OR-based dependency configurations to handle missing data sources gracefully. Transformations can now specify alternative dependencies using array syntax, allowing processing to continue when at least one dependency has data available.

Key changes:
- Support mixed dependency types (strings and arrays) in transformation configs
- Validate that at least one dependency in OR groups has data
- Calculate processing ranges flexibly based on available dependencies
- Add comprehensive tests for OR dependency scenarios
- Include example transformations demonstrating OR dependency usage

Closes #24