### PR TITLE
fix: make ClickHouse timeouts configurable and increase defaults

### DIFF
--- a/example/config.yaml
+++ b/example/config.yaml
@@ -18,8 +18,8 @@ clickhouse:
   url: "http://clickhouse:8123"
   cluster: ""
   localSuffix: "_local"
-  queryTimeout: 30s
-  insertTimeout: 60s
+  queryTimeout: 300s  # Increased from 30s to handle large queries
+  insertTimeout: 5m    # Increased from 60s for bulk operations
   debug: false
   keepAlive: 30s
   # Admin table uses defaults (admin.cbt)


### PR DESCRIPTION
- Use configured timeout values from config instead of hardcoded values
- Increase default query timeout from 30s to 300s for large queries
- Increase default insert timeout from 60s to 5m for bulk operations