### PR TITLE
fix: prevent duplicate task execution race condition in partial interval processing

### DIFF
--- a/pkg/tasks/payload.go
+++ b/pkg/tasks/payload.go
@@ -15,7 +15,7 @@ type TaskPayload struct {
 
 // UniqueID returns a unique identifier for this task
 func (p TaskPayload) UniqueID() string {
-	return fmt.Sprintf("%s:%d:%d", p.ModelID, p.Position, p.Interval)
+	return fmt.Sprintf("%s:%d", p.ModelID, p.Position)
 }
 
 // QueueName returns the queue name for this task payload

--- a/pkg/tasks/payload_test.go
+++ b/pkg/tasks/payload_test.go
@@ -21,7 +21,7 @@ func TestTaskPayload_UniqueID(t *testing.T) {
 				Position: 100,
 				Interval: 50,
 			},
-			expected: "model.test:100:50",
+			expected: "model.test:100",
 		},
 		{
 			name: "zero values",
@@ -30,7 +30,7 @@ func TestTaskPayload_UniqueID(t *testing.T) {
 				Position: 0,
 				Interval: 0,
 			},
-			expected: "model.zero:0:0",
+			expected: "model.zero:0",
 		},
 		{
 			name: "large values",
@@ -39,7 +39,7 @@ func TestTaskPayload_UniqueID(t *testing.T) {
 				Position: 18446744073709551615,
 				Interval: 18446744073709551615,
 			},
-			expected: "model.large:18446744073709551615:18446744073709551615",
+			expected: "model.large:18446744073709551615",
 		},
 		{
 			name: "with special characters in model ID",
@@ -48,7 +48,7 @@ func TestTaskPayload_UniqueID(t *testing.T) {
 				Position: 500,
 				Interval: 100,
 			},
-			expected: "model.test-123_v2:500:100",
+			expected: "model.test-123_v2:500",
 		},
 	}
 
@@ -142,10 +142,10 @@ func TestTaskPayload_UniqueID_Consistency(t *testing.T) {
 	payload2.Position = 200
 	assert.NotEqual(t, payload1.UniqueID(), payload2.UniqueID())
 
-	// Different interval should produce different unique ID
+	// Different interval should NOT affect unique ID anymore
 	payload2.Position = 100
 	payload2.Interval = 100
-	assert.NotEqual(t, payload1.UniqueID(), payload2.UniqueID())
+	assert.Equal(t, payload1.UniqueID(), payload2.UniqueID())
 
 	// Different model ID should produce different unique ID
 	payload2.Interval = 50


### PR DESCRIPTION
## Problem

When using partial interval processing (interval.min < interval.max), a critical race condition could occur causing duplicate task execution:

### Scenario
- ModelB has interval.max=10, schedules every 10s, but takes 60s to execute
- ModelA (dependency) updates bounds every 1s
- T=0s: ModelB enqueues task "modelB:100:5" (only 5 units available)
- T=10s: ModelB still running, but ModelA bounds increased by 10
- Scheduler enqueues "modelB:100:10" - different UniqueID due to interval change
- Result: Multiple overlapping tasks processing same position range

### Root Cause
The UniqueID included interval: fmt.Sprintf("%s:%d:%d", ModelID, Position, Interval) This made tasks with same position but different intervals appear unique, bypassing asynq's deduplication mechanism.

## Solution

Changed UniqueID to exclude interval: fmt.Sprintf("%s:%d", ModelID, Position)

### Benefits
- Only one task per position can exist in the queue
- Prevents duplicate processing of same data range
- Maintains idempotency even with dynamic interval sizing
- No complex refactoring required - minimal change

### Trade-offs
- Tasks won't "catch up" in single large interval if bounds grow significantly
- Will process in sequential chunks (safer for memory/timeouts anyway)

The interval remains in the payload for execution context but is no longer part of the unique identifier, elegantly solving the race condition.