### PR TITLE
fix: prevent overlapping task execution by using direction-based unique IDs

### DIFF
--- a/pkg/admin/service.go
+++ b/pkg/admin/service.go
@@ -514,7 +514,7 @@ func (a *service) ConsolidateHistoricalData(ctx context.Context, modelID string)
 	if a.cluster != "" {
 		// Cluster mode: use local suffix and ON CLUSTER
 		deleteQuery = fmt.Sprintf(`
-			DELETE FROM `+"`%s`.`%s`%s"+` ON CLUSTER '%s'
+			DELETE FROM `+"`%s`.`%s%s`"+` ON CLUSTER '%s'
 			WHERE database = '%s' AND table = '%s'
 			  AND position >= %d AND position < %d
 			  AND NOT (position = %d AND interval = %d)

--- a/pkg/tasks/payload.go
+++ b/pkg/tasks/payload.go
@@ -5,17 +5,25 @@ import (
 	"time"
 )
 
+const (
+	// DirectionForward represents forward fill processing
+	DirectionForward = "forward"
+	// DirectionBack represents backfill processing
+	DirectionBack = "back"
+)
+
 // TaskPayload represents the payload for a transformation task
 type TaskPayload struct {
 	ModelID    string    `json:"model_id"`
 	Position   uint64    `json:"position"`
 	Interval   uint64    `json:"interval"`
+	Direction  string    `json:"direction"` // DirectionForward or DirectionBack
 	EnqueuedAt time.Time `json:"enqueued_at"`
 }
 
 // UniqueID returns a unique identifier for this task
 func (p TaskPayload) UniqueID() string {
-	return fmt.Sprintf("%s:%d", p.ModelID, p.Position)
+	return fmt.Sprintf("%s:%s", p.ModelID, p.Direction)
 }
 
 // QueueName returns the queue name for this task payload


### PR DESCRIPTION
## Problem

Critical race condition in task processing was causing overlapping data ranges:
- Multiple forward fill tasks running concurrently with overlapping intervals
- Example: Tasks at positions 1758259079, 1758259091, 1758259127 all with 384 interval
- These tasks had 90%+ overlap, processing the same data multiple times
- Root cause: UniqueID included position, allowing multiple tasks per model

### How it happened
1. Slow transformation takes 60+ seconds to complete
2. Scheduler runs every 10 seconds
3. Each run creates a new task with slightly different position
4. All tasks get unique IDs (different positions) and run concurrently
5. Result: Massive overlap and duplicate processing

## Solution

Changed UniqueID from `modelID:position` to `modelID:direction`:
- Only ONE forward fill task per model can exist at any time
- Only ONE backfill task per model can exist at any time
- Completely prevents overlapping ranges
- Tasks process sequentially, not concurrently

### Implementation
- Added Direction field to TaskPayload ("forward" or "back")
- Updated UniqueID to use direction instead of position
- Added constants DirectionForward and DirectionBack
- Updated all task enqueue calls to pass direction
- Updated tests for new unique ID format

## Additional Fix

Fixed SQL syntax error in consolidation DELETE query:
- Moved `_local` suffix inside backticks for proper table name formatting
- Prevents "SYNTAX_ERROR" in cluster mode consolidation

This change is a breaking change but necessary to ensure data consistency and prevent resource exhaustion from overlapping tasks.