### PR TITLE
fix: prevent disruption of existing scheduled tasks during reconciliation

### DIFF
--- a/pkg/scheduler/service_test.go
+++ b/pkg/scheduler/service_test.go
@@ -528,3 +528,123 @@ func (m *mockTransformation) SetDefaultDatabase(defaultDB string) {
 }
 
 var _ models.Transformation = (*mockTransformation)(nil)
+
+// TestEmptyScheduleHandling tests that empty schedule values are handled gracefully
+func TestEmptyScheduleHandling(t *testing.T) {
+	tests := []struct {
+		name                string
+		forwardFillSchedule string
+		backfillSchedule    string
+		expectError         bool
+		description         string
+	}{
+		{
+			name:                "both schedules empty",
+			forwardFillSchedule: "",
+			backfillSchedule:    "",
+			expectError:         false,
+			description:         "Empty schedules should not cause errors",
+		},
+		{
+			name:                "forward empty, backfill set",
+			forwardFillSchedule: "",
+			backfillSchedule:    "@every 5m",
+			expectError:         false,
+			description:         "Only backfill should be registered",
+		},
+		{
+			name:                "forward set, backfill empty",
+			forwardFillSchedule: "@every 1m",
+			backfillSchedule:    "",
+			expectError:         false,
+			description:         "Only forward fill should be registered",
+		},
+		{
+			name:                "both schedules set",
+			forwardFillSchedule: "@every 1m",
+			backfillSchedule:    "@every 5m",
+			expectError:         false,
+			description:         "Both tasks should be registered",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup
+			logger := logrus.New()
+			logger.SetLevel(logrus.DebugLevel)
+
+			redisOpt := &redis.Options{
+				Addr: "localhost:6379",
+			}
+
+			// Create mock DAG with test transformation
+			mockTransformation := &mockTransformation{
+				id: "test.model",
+				conf: transformation.Config{
+					Database: "test_db",
+					Table:    "test_table",
+					Schedules: &transformation.SchedulesConfig{
+						ForwardFill: tt.forwardFillSchedule,
+						Backfill:    tt.backfillSchedule,
+					},
+				},
+			}
+
+			mockDAG := &mockDAGReader{
+				transformations: []models.Transformation{mockTransformation},
+			}
+
+			mockCoordinator := &mockCoordinator{}
+
+			cfg := &Config{
+				Concurrency:   10,
+				Consolidation: "", // Empty consolidation schedule
+			}
+
+			// Create service
+			svc, err := NewService(logger, cfg, redisOpt, mockDAG, mockCoordinator)
+			require.NoError(t, err)
+
+			s := svc.(*service)
+
+			// Test reconcileSchedules
+			err = s.reconcileSchedules()
+
+			if tt.expectError {
+				assert.Error(t, err, tt.description)
+			} else {
+				assert.NoError(t, err, tt.description)
+			}
+		})
+	}
+}
+
+// TestRegisterScheduledTaskWithEmptySchedule tests the registerScheduledTask method directly
+func TestRegisterScheduledTaskWithEmptySchedule(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.DebugLevel)
+
+	redisOpt := &redis.Options{
+		Addr: "localhost:6379",
+	}
+
+	mockDAG := &mockDAGReader{}
+	mockCoordinator := &mockCoordinator{}
+
+	cfg := &Config{
+		Concurrency: 10,
+	}
+
+	svc, err := NewService(logger, cfg, redisOpt, mockDAG, mockCoordinator)
+	require.NoError(t, err)
+
+	s := svc.(*service)
+
+	// Test with empty schedule - should not error
+	err = s.registerScheduledTask("test:task", "")
+	assert.NoError(t, err, "Empty schedule should not cause error")
+
+	// Test with valid schedule - would error without real Redis but that's OK for this test
+	// We're just verifying the empty schedule path doesn't panic
+}


### PR DESCRIPTION
- Check for existing scheduled tasks before registering
- Only update tasks when their schedule has changed
- Skip registration entirely for empty schedules
- Add reconciliation statistics logging