### PR TITLE
feat: implement Redis-based leader election for scheduler

### DIFF
--- a/example/scripts/test-leader-election.sh
+++ b/example/scripts/test-leader-election.sh
@@ -1,0 +1,235 @@
+#!/bin/bash
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}=== CBT Leader Election Test Script ===${NC}\n"
+
+# Function to get container names
+get_containers() {
+    # Support both docker-compose v1 (cbt-example-engine-1) and v2 (example-engine-1) naming
+    docker ps --filter "name=engine" --format "{{.Names}}" | grep -E "engine-[0-9]" | sort
+}
+
+# Function to get leader from Redis
+get_leader() {
+    docker exec cbt-redis redis-cli GET "cbt:scheduler:leader" 2>/dev/null || echo "none"
+}
+
+# Function to get leader container name
+get_leader_container() {
+    local leader_id=$(get_leader)
+    if [ "$leader_id" = "none" ]; then
+        echo "none"
+        return
+    fi
+    
+    # Search logs for the instance ID to find which container is leader
+    for container in $(get_containers); do
+        if docker logs "$container" 2>&1 | grep -q "instance_id=$leader_id.*Promoted to leader"; then
+            echo "$container"
+            return
+        fi
+    done
+    echo "unknown"
+}
+
+# Function to check scheduler entries
+check_scheduler_entries() {
+    echo -e "${YELLOW}Scheduler Entries in Redis:${NC}"
+    docker exec cbt-redis redis-cli --scan --pattern "asynq:*scheduler*" | while read key; do
+        echo "  - $key"
+    done
+    echo ""
+}
+
+# Function to show leader election events
+show_election_events() {
+    echo -e "${YELLOW}Recent Leader Election Events:${NC}"
+    for container in $(get_containers); do
+        echo -e "${BLUE}[$container]${NC}"
+        docker logs "$container" 2>&1 | grep -E "Promoted to|Demoted from|Starting leader election" | tail -3
+    done
+    echo ""
+}
+
+# Main test scenarios
+case "${1:-status}" in
+    status)
+        echo -e "${GREEN}Current Leader Election Status:${NC}\n"
+        
+        containers=$(get_containers)
+        echo -e "${YELLOW}Running Containers:${NC}"
+        echo "$containers" | nl
+        echo ""
+        
+        leader=$(get_leader)
+        echo -e "${YELLOW}Leader Lock in Redis:${NC}"
+        if [ "$leader" = "none" ]; then
+            echo -e "${RED}  No leader elected!${NC}"
+        else
+            echo -e "${GREEN}  $leader${NC}"
+        fi
+        echo ""
+        
+        leader_container=$(get_leader_container)
+        echo -e "${YELLOW}Leader Container:${NC}"
+        if [ "$leader_container" = "none" ]; then
+            echo -e "${RED}  No leader${NC}"
+        elif [ "$leader_container" = "unknown" ]; then
+            echo -e "${YELLOW}  Unknown (logs not found)${NC}"
+        else
+            echo -e "${GREEN}  $leader_container${NC}"
+        fi
+        echo ""
+        
+        check_scheduler_entries
+        show_election_events
+        ;;
+        
+    watch)
+        echo -e "${GREEN}Watching leader election (Ctrl+C to stop)...${NC}\n"
+        while true; do
+            clear
+            echo -e "${BLUE}=== Leader Election Status ($(date +%H:%M:%S)) ===${NC}\n"
+            
+            leader=$(get_leader)
+            echo -e "${YELLOW}Current Leader:${NC} ${GREEN}$leader${NC}"
+            
+            echo -e "\n${YELLOW}Container Status:${NC}"
+            for container in $(get_containers); do
+                status=$(docker inspect "$container" --format '{{.State.Status}}')
+                if docker logs "$container" 2>&1 | tail -20 | grep -q "Promoted to leader"; then
+                    echo -e "  ${GREEN}● $container${NC} (status: $status) ${GREEN}[LEADER]${NC}"
+                else
+                    echo -e "  ${BLUE}○ $container${NC} (status: $status)"
+                fi
+            done
+            
+            echo -e "\n${YELLOW}Recent Logs (last 3 lines):${NC}"
+            for container in $(get_containers); do
+                echo -e "${BLUE}[$container]${NC}"
+                docker logs "$container" 2>&1 | grep -E "leader|election|Promoted|Demoted" | tail -3 | sed 's/^/  /'
+            done
+            
+            sleep 3
+        done
+        ;;
+        
+    failover)
+        echo -e "${GREEN}Testing Leader Failover...${NC}\n"
+        
+        leader_container=$(get_leader_container)
+        if [ "$leader_container" = "none" ] || [ "$leader_container" = "unknown" ]; then
+            echo -e "${RED}No leader found to stop${NC}"
+            exit 1
+        fi
+        
+        echo -e "${YELLOW}Current leader:${NC} $leader_container"
+        echo -e "${YELLOW}Stopping leader container...${NC}"
+        docker stop "$leader_container"
+        
+        echo -e "\n${YELLOW}Waiting for failover (15 seconds)...${NC}"
+        for i in {15..1}; do
+            echo -ne "\r  ${i}s remaining..."
+            sleep 1
+        done
+        echo ""
+        
+        new_leader=$(get_leader)
+        new_container=$(get_leader_container)
+        
+        echo -e "\n${GREEN}Failover Complete!${NC}"
+        echo -e "${YELLOW}New Leader:${NC} ${GREEN}$new_leader${NC}"
+        echo -e "${YELLOW}New Leader Container:${NC} ${GREEN}$new_container${NC}\n"
+        
+        echo -e "${YELLOW}Restarting stopped container...${NC}"
+        docker start "$leader_container"
+        
+        echo -e "\n${GREEN}Failover test complete. Container restarted as follower.${NC}"
+        ;;
+        
+    rolling-deploy)
+        echo -e "${GREEN}Simulating Rolling Deployment...${NC}\n"
+        
+        containers=($(get_containers))
+        
+        for i in "${!containers[@]}"; do
+            container="${containers[$i]}"
+            is_leader=false
+            
+            if [ "$(get_leader_container)" = "$container" ]; then
+                is_leader=true
+                echo -e "${YELLOW}Container $((i+1))/${#containers[@]}:${NC} ${GREEN}$container [LEADER]${NC}"
+            else
+                echo -e "${YELLOW}Container $((i+1))/${#containers[@]}:${NC} $container"
+            fi
+            
+            echo "  Restarting..."
+            docker restart "$container" > /dev/null
+            
+            if [ "$is_leader" = true ]; then
+                echo "  Was leader, waiting for failover (15s)..."
+                sleep 15
+            else
+                echo "  Waiting for stabilization (5s)..."
+                sleep 5
+            fi
+            
+            new_leader=$(get_leader_container)
+            echo -e "  Current leader: ${GREEN}$new_leader${NC}\n"
+        done
+        
+        echo -e "${GREEN}Rolling deployment complete!${NC}"
+        echo ""
+        $0 status
+        ;;
+        
+    logs)
+        echo -e "${GREEN}Streaming leader election logs (Ctrl+C to stop)...${NC}\n"
+        docker compose -f ../docker-compose.yml logs -f engine | grep --line-buffered -E "election|leader|Promoted|Demoted"
+        ;;
+        
+    redis)
+        echo -e "${GREEN}Redis Inspection:${NC}\n"
+        
+        echo -e "${YELLOW}Leader Lock:${NC}"
+        docker exec cbt-redis redis-cli GET "cbt:scheduler:leader"
+        echo ""
+        
+        echo -e "${YELLOW}Leader Lock TTL:${NC}"
+        ttl=$(docker exec cbt-redis redis-cli TTL "cbt:scheduler:leader")
+        echo "$ttl seconds"
+        echo ""
+        
+        echo -e "${YELLOW}All CBT Keys:${NC}"
+        docker exec cbt-redis redis-cli KEYS "cbt:*"
+        echo ""
+        
+        echo -e "${YELLOW}Scheduler Entries:${NC}"
+        docker exec cbt-redis redis-cli KEYS "asynq:*scheduler*"
+        echo ""
+        ;;
+        
+    help|*)
+        echo "Usage: $0 {status|watch|failover|rolling-deploy|logs|redis|help}"
+        echo ""
+        echo "Commands:"
+        echo "  status          - Show current leader election status"
+        echo "  watch           - Watch leader election status in real-time"
+        echo "  failover        - Test leader failover by stopping current leader"
+        echo "  rolling-deploy  - Simulate a rolling deployment"
+        echo "  logs            - Stream leader election logs"
+        echo "  redis           - Inspect Redis keys and leader lock"
+        echo "  help            - Show this help message"
+        echo ""
+        echo "Monitoring UIs:"
+        echo "  Asynqmon:        http://localhost:8080"
+        echo "  Redis Commander: http://localhost:8081"
+        ;;
+esac

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/ClickHouse/ch-go v0.67.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.3.0 // indirect
+	github.com/alicebob/miniredis/v2 v2.35.0 // indirect
 	github.com/andybalholm/brotli v1.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
@@ -57,6 +58,7 @@ require (
 	github.com/spf13/cast v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.opentelemetry.io/otel v1.37.0 // indirect
 	go.opentelemetry.io/otel/trace v1.37.0 // indirect
 	golang.org/x/crypto v0.40.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/Masterminds/semver/v3 v3.3.0 h1:B8LGeaivUe71a5qox1ICM/JLl0NqZSW5CHyL+
 github.com/Masterminds/semver/v3 v3.3.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Masterminds/sprig/v3 v3.3.0 h1:mQh0Yrg1XPo6vjYXgtf5OtijNAKJRNcTdOOGZe3tPhs=
 github.com/Masterminds/sprig/v3 v3.3.0/go.mod h1:Zy1iXRYNqNLUolqCpL4uhk6SHUMAOSCzdgBfDb35Lz0=
+github.com/alicebob/miniredis/v2 v2.35.0 h1:QwLphYqCEAo1eu1TqPRN2jgVMPBweeQcR21jeqDCONI=
+github.com/alicebob/miniredis/v2 v2.35.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -136,6 +138,8 @@ github.com/xdg-go/stringprep v1.0.3/go.mod h1:W3f5j4i+9rC0kuIEJL0ky1VpHXQU3ocBgk
 github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d/go.mod h1:rHwXgn7JulP+udvsHwJoVG1YGAP6VLg4y9I5dyZdqmA=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 go.mongodb.org/mongo-driver v1.11.4/go.mod h1:PTSz5yu21bkT/wXpkS7WR5f0ddqw5quethTUn9WM+2g=
 go.opentelemetry.io/otel v1.37.0 h1:9zhNfelUvx0KBfu/gb+ZgeAfAgtWrfHJZcAqFC228wQ=
 go.opentelemetry.io/otel v1.37.0/go.mod h1:ehE/umFRLnuLa/vSccNq9oS1ErUlkkK71gMcN34UG8I=

--- a/pkg/scheduler/election.go
+++ b/pkg/scheduler/election.go
@@ -1,0 +1,229 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	leaderKeyPrefix = "cbt:scheduler:leader"
+	leaseTTL        = 10 * time.Second
+	renewInterval   = 3 * time.Second
+)
+
+var (
+	// ErrElectorStopped is returned when the elector is stopped while waiting for leadership
+	ErrElectorStopped = errors.New("elector stopped while waiting for leadership")
+)
+
+// LeaderElector manages distributed leader election using Redis
+type LeaderElector interface {
+	Start(ctx context.Context) error
+	Stop() error
+	IsLeader() bool
+	WaitForLeadership(ctx context.Context) error
+}
+
+// elector implements the LeaderElector interface
+type elector struct {
+	log        logrus.FieldLogger
+	redis      *redis.Client
+	instanceID string
+	leaderKey  string
+
+	isLeader bool
+	mu       sync.RWMutex
+
+	done chan struct{}
+	wg   sync.WaitGroup
+
+	promoted chan struct{}
+	demoted  chan struct{}
+}
+
+// NewLeaderElector creates a new leader elector instance
+func NewLeaderElector(log logrus.FieldLogger, redisOpt *redis.Options) LeaderElector {
+	instanceID := uuid.New().String()
+
+	return &elector{
+		log:        log.WithField("component", "election"),
+		redis:      redis.NewClient(redisOpt),
+		instanceID: instanceID,
+		leaderKey:  leaderKeyPrefix,
+		done:       make(chan struct{}),
+		promoted:   make(chan struct{}, 1),
+		demoted:    make(chan struct{}, 1),
+	}
+}
+
+func (e *elector) Start(ctx context.Context) error {
+	e.log.WithField("instance_id", e.instanceID).Info("Starting leader election")
+
+	e.wg.Add(1)
+	go e.run(ctx)
+
+	return nil
+}
+
+func (e *elector) Stop() error {
+	e.log.Info("Stopping leader election")
+	close(e.done)
+
+	e.relinquish(context.Background())
+
+	e.wg.Wait()
+
+	if err := e.redis.Close(); err != nil {
+		e.log.WithError(err).Warn("Failed to close Redis client")
+	}
+
+	e.log.Info("Leader election stopped")
+	return nil
+}
+
+func (e *elector) run(ctx context.Context) {
+	defer e.wg.Done()
+
+	ticker := time.NewTicker(renewInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-e.done:
+			return
+
+		case <-ctx.Done():
+			return
+
+		case <-ticker.C:
+			wasLeader := e.IsLeader()
+			acquired := e.tryAcquire(ctx)
+
+			if acquired && !wasLeader {
+				e.setLeader(true)
+				e.log.WithField("instance_id", e.instanceID).Info("Promoted to leader")
+
+				select {
+				case e.promoted <- struct{}{}:
+				default:
+				}
+			} else if !acquired && wasLeader {
+				e.setLeader(false)
+				e.log.WithField("instance_id", e.instanceID).Info("Demoted from leader")
+
+				select {
+				case e.demoted <- struct{}{}:
+				default:
+				}
+			}
+		}
+	}
+}
+
+func (e *elector) tryAcquire(ctx context.Context) bool {
+	result, err := e.redis.SetNX(ctx, e.leaderKey, e.instanceID, leaseTTL).Result()
+	if err != nil {
+		e.log.WithError(err).Debug("Failed to acquire leader lock")
+		return false
+	}
+
+	if result {
+		e.log.WithFields(logrus.Fields{
+			"instance_id": e.instanceID,
+			"ttl":         leaseTTL,
+		}).Debug("Acquired leader lock")
+		return true
+	}
+
+	owner, err := e.redis.Get(ctx, e.leaderKey).Result()
+	if err != nil {
+		if !errors.Is(err, redis.Nil) {
+			e.log.WithError(err).Debug("Failed to check lock owner")
+		}
+		return false
+	}
+
+	if owner == e.instanceID {
+		if err := e.redis.Expire(ctx, e.leaderKey, leaseTTL).Err(); err != nil {
+			e.log.WithError(err).Warn("Failed to renew leader lease")
+			return false
+		}
+
+		e.log.WithFields(logrus.Fields{
+			"instance_id": e.instanceID,
+			"ttl":         leaseTTL,
+		}).Debug("Renewed leader lease")
+		return true
+	}
+
+	e.log.WithFields(logrus.Fields{
+		"current_leader": owner,
+		"instance_id":    e.instanceID,
+	}).Debug("Another instance holds leadership")
+
+	return false
+}
+
+func (e *elector) relinquish(ctx context.Context) {
+	if !e.IsLeader() {
+		return
+	}
+
+	owner, err := e.redis.Get(ctx, e.leaderKey).Result()
+	if err == nil && owner == e.instanceID {
+		if err := e.redis.Del(ctx, e.leaderKey).Err(); err != nil {
+			e.log.WithError(err).Warn("Failed to delete leader lock")
+		} else {
+			e.log.WithField("instance_id", e.instanceID).Info("Relinquished leader lock")
+		}
+	}
+
+	e.setLeader(false)
+}
+
+func (e *elector) setLeader(isLeader bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.isLeader = isLeader
+}
+
+func (e *elector) IsLeader() bool {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return e.isLeader
+}
+
+func (e *elector) WaitForLeadership(ctx context.Context) error {
+	if e.IsLeader() {
+		return nil
+	}
+
+	e.log.Info("Waiting for leadership promotion")
+
+	select {
+	case <-e.promoted:
+		e.log.Info("Leadership acquired")
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("context canceled while waiting for leadership: %w", ctx.Err())
+	case <-e.done:
+		return ErrElectorStopped
+	}
+}
+
+func (e *elector) PromotedChan() <-chan struct{} {
+	return e.promoted
+}
+
+func (e *elector) DemotedChan() <-chan struct{} {
+	return e.demoted
+}
+
+var _ LeaderElector = (*elector)(nil)

--- a/pkg/scheduler/election_test.go
+++ b/pkg/scheduler/election_test.go
@@ -1,0 +1,138 @@
+package scheduler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLeaderElection(t *testing.T) {
+	// Start mini redis
+	mr, err := miniredis.Run()
+	require.NoError(t, err)
+	defer mr.Close()
+
+	log := logrus.New()
+	log.SetLevel(logrus.DebugLevel)
+
+	redisOpt := &redis.Options{
+		Addr: mr.Addr(),
+	}
+
+	t.Run("single instance becomes leader", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		// Clear any existing locks
+		mr.FlushAll()
+
+		elector := NewLeaderElector(log, redisOpt)
+		require.NoError(t, elector.Start(ctx))
+		defer elector.Stop()
+
+		// Wait a bit for election to occur
+		time.Sleep(renewInterval + 500*time.Millisecond)
+
+		assert.True(t, elector.IsLeader(), "Single instance should become leader")
+	})
+
+	t.Run("multiple instances elect one leader", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		// Clear any existing locks
+		mr.FlushAll()
+
+		elector1 := NewLeaderElector(log, redisOpt)
+		elector2 := NewLeaderElector(log, redisOpt)
+
+		require.NoError(t, elector1.Start(ctx))
+		defer elector1.Stop()
+
+		require.NoError(t, elector2.Start(ctx))
+		defer elector2.Stop()
+
+		// Wait for election
+		time.Sleep(renewInterval + 500*time.Millisecond)
+
+		// Exactly one should be leader
+		leaders := 0
+		if elector1.IsLeader() {
+			leaders++
+		}
+		if elector2.IsLeader() {
+			leaders++
+		}
+
+		assert.Equal(t, 1, leaders, "Exactly one instance should be leader")
+	})
+
+	t.Run("leader failover", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+
+		// Clear any existing locks
+		mr.FlushAll()
+
+		elector1 := NewLeaderElector(log, redisOpt)
+		elector2 := NewLeaderElector(log, redisOpt)
+
+		require.NoError(t, elector1.Start(ctx))
+		require.NoError(t, elector2.Start(ctx))
+
+		// Wait for election
+		time.Sleep(renewInterval + 500*time.Millisecond)
+
+		// Determine who is leader and stop them
+		var leader, follower LeaderElector
+		if elector1.IsLeader() {
+			leader = elector1
+			follower = elector2
+			defer elector2.Stop()
+		} else {
+			leader = elector2
+			follower = elector1
+			defer elector1.Stop()
+		}
+
+		require.NoError(t, leader.Stop())
+
+		// Wait for lease to expire and new election
+		// The follower should detect the expired lock and take over
+		time.Sleep(leaseTTL + renewInterval + 500*time.Millisecond)
+
+		assert.True(t, follower.IsLeader(), "Follower should become leader after leader stops")
+	})
+
+	t.Run("wait for leadership", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		// Clear any existing locks
+		mr.FlushAll()
+
+		elector := NewLeaderElector(log, redisOpt)
+		require.NoError(t, elector.Start(ctx))
+		defer elector.Stop()
+
+		// Wait in goroutine to avoid blocking
+		done := make(chan error, 1)
+		go func() {
+			done <- elector.WaitForLeadership(ctx)
+		}()
+
+		select {
+		case err := <-done:
+			require.NoError(t, err)
+			assert.True(t, elector.IsLeader())
+		case <-time.After(renewInterval + time.Second):
+			t.Fatal("Timed out waiting for leadership")
+		}
+	})
+}


### PR DESCRIPTION
Adds distributed leader election to ensure only one scheduler instance runs at a time, preventing scheduled task loss during rolling deployments. The elected leader reconciles and manages all scheduled tasks, with automatic failover when the leader stops.

- Add LeaderElector interface with Redis-based implementation
- Integrate leader election into scheduler service lifecycle
- Add comprehensive unit tests using miniredis
- Include test script for docker-compose validation
- Leader lease TTL: 10s with 3s renewal interval