### PR TITLE
fix: remove duplicate admin writes and broken INSERT verification

### DIFF
--- a/pkg/admin/service.go
+++ b/pkg/admin/service.go
@@ -111,7 +111,27 @@ func (a *service) RecordCompletion(ctx context.Context, modelID string, position
 		VALUES (now(), '%s', '%s', %d, %d)
 	`, a.adminDatabase, a.adminTable, parts[0], parts[1], position, interval)
 
-	return a.client.Execute(ctx, query)
+	body, err := a.client.Execute(ctx, query)
+	if err != nil {
+		return fmt.Errorf("failed to insert admin record: %w", err)
+	}
+
+	// Log the raw response for debugging (helps troubleshoot issues)
+	if len(body) > 0 {
+		a.log.WithFields(logrus.Fields{
+			"model_id":      modelID,
+			"position":      position,
+			"interval":      interval,
+			"response_body": string(body),
+		}).Debug("Admin table INSERT response")
+	}
+
+	// ClickHouse HTTP INSERT queries return:
+	// - Empty body on success (most common)
+	// - "Ok." or similar text on success
+	// - Error message on failure (already handled by Execute())
+
+	return nil
 }
 
 // GetFirstPosition returns the first processed position for a model
@@ -503,7 +523,7 @@ func (a *service) ConsolidateHistoricalData(ctx context.Context, modelID string)
 		VALUES (now(), '%s', '%s', %d, %d)
 	`, a.adminDatabase, a.adminTable, database, table, rangeResult.StartPos, consolidatedInterval)
 
-	if err := a.client.Execute(ctx, insertQuery); err != nil {
+	if _, err := a.client.Execute(ctx, insertQuery); err != nil {
 		return 0, fmt.Errorf("failed to insert consolidated row: %w", err)
 	}
 
@@ -533,7 +553,7 @@ func (a *service) ConsolidateHistoricalData(ctx context.Context, modelID string)
 			rangeResult.StartPos, consolidatedInterval)
 	}
 
-	if err := a.client.Execute(ctx, deleteQuery); err != nil {
+	if _, err := a.client.Execute(ctx, deleteQuery); err != nil {
 		// Log error but don't fail - the consolidated row will eventually replace the old ones
 		// due to ReplacingMergeTree behavior
 		return rangeResult.RowCount, fmt.Errorf("consolidated row inserted but failed to delete old rows: %w", err)

--- a/pkg/admin/service_test.go
+++ b/pkg/admin/service_test.go
@@ -369,8 +369,12 @@ type mockClickhouseClient struct {
 	executeError   error
 }
 
-func (m *mockClickhouseClient) Execute(_ context.Context, _ string) error {
-	return m.executeError
+func (m *mockClickhouseClient) Execute(_ context.Context, _ string) ([]byte, error) {
+	if m.executeError != nil {
+		return nil, m.executeError
+	}
+	// Return a mock response with 1 row written
+	return []byte(`{"written_rows":"1"}`), nil
 }
 
 func (m *mockClickhouseClient) QueryOne(_ context.Context, _ string, result interface{}) error {
@@ -582,9 +586,9 @@ type queryCapturingClient struct {
 	resultIndex int
 }
 
-func (m *queryCapturingClient) Execute(_ context.Context, query string) error {
+func (m *queryCapturingClient) Execute(_ context.Context, query string) ([]byte, error) {
 	m.queries = append(m.queries, query)
-	return nil
+	return []byte(`{"written_rows":"1"}`), nil
 }
 
 func (m *queryCapturingClient) QueryOne(_ context.Context, query string, result interface{}) error {

--- a/pkg/clickhouse/client_test.go
+++ b/pkg/clickhouse/client_test.go
@@ -209,7 +209,7 @@ func TestHTTPClient_Execute(t *testing.T) {
 	require.NoError(t, err)
 
 	// Execute command
-	err = client.Execute(context.Background(), "CREATE TABLE test_table (id UInt64) ENGINE = Memory")
+	_, err = client.Execute(context.Background(), "CREATE TABLE test_table (id UInt64) ENGINE = Memory")
 	require.NoError(t, err)
 }
 

--- a/pkg/clickhouse/schema.go
+++ b/pkg/clickhouse/schema.go
@@ -13,7 +13,8 @@ func EnsureDatabase(ctx context.Context, client ClientInterface, database, clust
 	} else {
 		query = fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`", database)
 	}
-	return client.Execute(ctx, query)
+	_, err := client.Execute(ctx, query)
+	return err
 }
 
 // TableExists checks if a table exists in the given database

--- a/pkg/scheduler/service.go
+++ b/pkg/scheduler/service.go
@@ -839,12 +839,15 @@ func (s *service) triggerInitialExternalScans(ctx context.Context) {
 		if s.admin != nil {
 			// Try to get bounds - if nil or initial scan incomplete, trigger initial scan
 			bounds, err := s.admin.GetExternalBounds(ctx, modelID)
-			s.log.WithFields(logrus.Fields{
+			logFields := logrus.Fields{
 				"model_id":              modelID,
 				"bounds_nil":            bounds == nil,
 				"initial_scan_complete": bounds != nil && bounds.InitialScanComplete,
-				"error":                 err,
-			}).Debug("Checked external model bounds")
+			}
+			if err != nil {
+				logFields["error"] = err
+			}
+			s.log.WithFields(logFields).Debug("Checked external model bounds")
 
 			if bounds == nil || !bounds.InitialScanComplete {
 				// Add jitter to prevent thundering herd (0-10 seconds)

--- a/pkg/validation/external_test.go
+++ b/pkg/validation/external_test.go
@@ -32,8 +32,8 @@ func (m *testClickHouseClient) QueryMany(_ context.Context, _ string, _ interfac
 	return nil
 }
 
-func (m *testClickHouseClient) Execute(_ context.Context, _ string) error {
-	return nil
+func (m *testClickHouseClient) Execute(_ context.Context, _ string) ([]byte, error) {
+	return nil, nil
 }
 
 func (m *testClickHouseClient) BulkInsert(_ context.Context, _ string, _ interface{}) error {

--- a/pkg/validation/validator_test.go
+++ b/pkg/validation/validator_test.go
@@ -993,7 +993,7 @@ func (m *mockClickhouseClient) QueryOne(_ context.Context, _ string, _ interface
 func (m *mockClickhouseClient) QueryMany(_ context.Context, _ string, _ interface{}) error {
 	return nil
 }
-func (m *mockClickhouseClient) Execute(_ context.Context, _ string) error { return nil }
+func (m *mockClickhouseClient) Execute(_ context.Context, _ string) ([]byte, error) { return nil, nil }
 func (m *mockClickhouseClient) BulkInsert(_ context.Context, _ string, _ interface{}) error {
 	return nil
 }

--- a/pkg/worker/executor.go
+++ b/pkg/worker/executor.go
@@ -280,11 +280,6 @@ func (e *ModelExecutor) Execute(ctx context.Context, taskCtxInterface interface{
 		return fmt.Errorf("%w: %s", ErrInvalidTransformationType, taskCtx.Transformation.GetType())
 	}
 
-	// Record completion in admin table
-	if err := e.admin.RecordCompletion(ctx, taskCtx.Transformation.GetID(), taskCtx.Position, taskCtx.Interval); err != nil {
-		return fmt.Errorf("failed to record completion: %w", err)
-	}
-
 	return nil
 }
 
@@ -345,7 +340,7 @@ func (e *ModelExecutor) executeSQL(ctx context.Context, taskCtx *tasks.TaskConte
 			"sql_preview":   logSQL,
 		}).Info("Executing SQL statement")
 
-		if err := e.chClient.Execute(ctx, stmt); err != nil {
+		if _, err := e.chClient.Execute(ctx, stmt); err != nil {
 			e.log.WithFields(logrus.Fields{
 				"statement": i + 1,
 				"sql":       logSQL,

--- a/pkg/worker/executor_test.go
+++ b/pkg/worker/executor_test.go
@@ -174,26 +174,6 @@ func TestModelExecutor_Execute(t *testing.T) {
 			},
 			wantErr: true,
 		},
-		{
-			name: "record completion fails",
-			setupMocks: func(ch *mockExecutorClickhouseClient, m *mockExecutorModelsService, a *mockExecutorAdminService) {
-				ch.tableExists = true
-				m.renderedSQL = "SELECT 1"
-				a.recordErr = errMockExecute
-			},
-			taskCtx: &tasks.TaskContext{
-				Transformation: &mockExecutorTransformation{
-					id:   "test.model",
-					typ:  transformation.TransformationTypeSQL,
-					sql:  "SELECT 1",
-					conf: transformation.Config{Database: "test", Table: "model"},
-				},
-				Position:  100,
-				Interval:  50,
-				StartTime: time.Now(),
-			},
-			wantErr: true,
-		},
 	}
 
 	for _, tt := range tests {
@@ -503,8 +483,8 @@ func (m *mockExecutorClickhouseClient) QueryOne(_ context.Context, query string,
 func (m *mockExecutorClickhouseClient) QueryMany(_ context.Context, _ string, _ interface{}) error {
 	return nil
 }
-func (m *mockExecutorClickhouseClient) Execute(_ context.Context, _ string) error {
-	return m.executeErr
+func (m *mockExecutorClickhouseClient) Execute(_ context.Context, _ string) ([]byte, error) {
+	return nil, m.executeErr
 }
 func (m *mockExecutorClickhouseClient) BulkInsert(_ context.Context, _ string, _ interface{}) error {
 	return nil

--- a/pkg/worker/service_test.go
+++ b/pkg/worker/service_test.go
@@ -257,7 +257,7 @@ func (m *mockClickhouseClient) QueryOne(_ context.Context, _ string, _ interface
 func (m *mockClickhouseClient) QueryMany(_ context.Context, _ string, _ interface{}) error {
 	return nil
 }
-func (m *mockClickhouseClient) Execute(_ context.Context, _ string) error { return nil }
+func (m *mockClickhouseClient) Execute(_ context.Context, _ string) ([]byte, error) { return nil, nil }
 func (m *mockClickhouseClient) BulkInsert(_ context.Context, _ string, _ interface{}) error {
 	return nil
 }


### PR DESCRIPTION
- Remove duplicate RecordCompletion call in worker/executor.go that was causing double admin table updates
- Change clickhouse.Execute() to return ([]byte, error) instead of just error for debugging
- Remove broken row count verification for INSERT queries (ClickHouse HTTP doesn't return row counts)
- Add debug logging for INSERT responses to help troubleshoot issues
- Fix scheduler logging to not show error='<nil>' when no error exists
- Update all mock implementations to match new Execute() signature