### PR TITLE
feat: implement external model overrides with type-aware resolution

### DIFF
--- a/pkg/models/dag_test.go
+++ b/pkg/models/dag_test.go
@@ -47,6 +47,7 @@ type mockExternal struct {
 
 func (m *mockExternal) GetID() string                       { return m.id }
 func (m *mockExternal) GetConfig() external.Config          { return m.config }
+func (m *mockExternal) GetConfigMutable() *external.Config  { return &m.config }
 func (m *mockExternal) GetType() string                     { return m.typ }
 func (m *mockExternal) GetSQL() string                      { return "" }
 func (m *mockExternal) GetValue() string                    { return "" }

--- a/pkg/models/external.go
+++ b/pkg/models/external.go
@@ -26,6 +26,7 @@ type External interface {
 	GetType() string
 	GetID() string
 	GetConfig() external.Config
+	GetConfigMutable() *external.Config
 	GetValue() string
 	SetDefaultDatabase(defaultDB string)
 }

--- a/pkg/models/external/sql.go
+++ b/pkg/models/external/sql.go
@@ -64,6 +64,11 @@ func (c *SQL) GetConfig() Config {
 	return c.Config
 }
 
+// GetConfigMutable returns a mutable pointer to the external model configuration
+func (c *SQL) GetConfigMutable() *Config {
+	return &c.Config
+}
+
 // GetValue returns the SQL content
 func (c *SQL) GetValue() string {
 	return c.Content

--- a/pkg/models/override.go
+++ b/pkg/models/override.go
@@ -1,13 +1,98 @@
 package models
 
 import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/ethpandaops/cbt/pkg/models/external"
 	"github.com/ethpandaops/cbt/pkg/models/transformation"
+	"gopkg.in/yaml.v3"
 )
 
+var (
+	// ErrUnknownModelType is returned when an unknown model type is encountered
+	ErrUnknownModelType = errors.New("unknown model type")
+)
+
+// ModelType identifies whether a model is external or transformation
+type ModelType string
+
+const (
+	// ModelTypeExternal identifies external models
+	ModelTypeExternal ModelType = "external"
+	// ModelTypeTransformation identifies transformation models
+	ModelTypeTransformation ModelType = "transformation"
+)
+
+// OverrideConfig defines the interface for override configurations
+type OverrideConfig interface {
+	applyToTransformation(config *transformation.Config)
+	applyToExternal(config *external.Config)
+}
+
 // ModelOverride represents configuration overrides for a specific model
+// The actual config is stored as raw YAML and unmarshaled based on model type
 type ModelOverride struct {
-	Enabled *bool                   `yaml:"enabled,omitempty"`
-	Config  *TransformationOverride `yaml:"config,omitempty"`
+	Enabled   *bool
+	rawConfig *yaml.Node
+	Config    OverrideConfig
+}
+
+// UnmarshalYAML implements custom unmarshaling for ModelOverride
+func (m *ModelOverride) UnmarshalYAML(node *yaml.Node) error {
+	// First unmarshal enabled field
+	var temp struct {
+		Enabled *bool `yaml:"enabled,omitempty"`
+	}
+
+	if err := node.Decode(&temp); err != nil {
+		return fmt.Errorf("failed to unmarshal override: %w", err)
+	}
+
+	m.Enabled = temp.Enabled
+
+	// Iterate through node content to find config field
+	// node.Content is a flat list of key-value pairs for maps
+	for i := 0; i < len(node.Content); i += 2 {
+		keyNode := node.Content[i]
+		valueNode := node.Content[i+1]
+
+		if keyNode.Value == "config" {
+			m.rawConfig = valueNode
+			break
+		}
+	}
+
+	return nil
+}
+
+// ResolveConfig unmarshals the raw config based on the actual model type
+func (m *ModelOverride) ResolveConfig(actualType ModelType) error {
+	if m.rawConfig == nil {
+		return nil
+	}
+
+	switch actualType {
+	case ModelTypeTransformation:
+		var config TransformationOverride
+		if err := m.rawConfig.Decode(&config); err != nil {
+			return fmt.Errorf("failed to unmarshal transformation config: %w", err)
+		}
+		m.Config = &config
+
+	case ModelTypeExternal:
+		var config ExternalOverride
+		if err := m.rawConfig.Decode(&config); err != nil {
+			return fmt.Errorf("failed to unmarshal external config: %w", err)
+		}
+		m.Config = &config
+
+	default:
+		return fmt.Errorf("%w: %s", ErrUnknownModelType, actualType)
+	}
+
+	return nil
 }
 
 // TransformationOverride contains override values for transformation model configurations
@@ -28,8 +113,8 @@ type IntervalOverride struct {
 // SchedulesOverride allows overriding schedule configuration
 // nil = keep existing, empty string = disable, non-empty = new schedule
 type SchedulesOverride struct {
-	ForwardFill *string `yaml:"forwardfill,omitempty"`
-	Backfill    *string `yaml:"backfill,omitempty"`
+	ForwardFill *string `yaml:"forwardfill"`
+	Backfill    *string `yaml:"backfill"`
 }
 
 // LimitsOverride allows overriding position limits
@@ -39,48 +124,59 @@ type LimitsOverride struct {
 }
 
 // ApplyToTransformation applies override configuration to a transformation model
-func (o *ModelOverride) ApplyToTransformation(config *transformation.Config) {
-	if o == nil || o.Config == nil {
+func (m *ModelOverride) ApplyToTransformation(config *transformation.Config) {
+	if m == nil || m.Config == nil {
 		return
 	}
 
-	o.applyIntervalOverrides(config)
-	o.applyScheduleOverrides(config)
-	o.applyLimitOverrides(config)
-	o.applyTagOverrides(config)
+	m.Config.applyToTransformation(config)
 }
 
-// applyIntervalOverrides applies interval configuration overrides
-func (o *ModelOverride) applyIntervalOverrides(config *transformation.Config) {
-	if o.Config.Interval == nil || config.Interval == nil {
+// IsDisabled returns true if the model is explicitly disabled
+func (m *ModelOverride) IsDisabled() bool {
+	return m != nil && m.Enabled != nil && !*m.Enabled
+}
+
+// TransformationOverride implements OverrideConfig for transformation models
+func (t *TransformationOverride) applyToTransformation(config *transformation.Config) {
+	t.applyIntervalOverrides(config)
+	t.applyScheduleOverrides(config)
+	t.applyLimitOverrides(config)
+	t.applyTagOverrides(config)
+}
+
+func (t *TransformationOverride) applyToExternal(_ *external.Config) {
+	// No-op: transformation overrides don't apply to external models
+}
+
+func (t *TransformationOverride) applyIntervalOverrides(config *transformation.Config) {
+	if t.Interval == nil || config.Interval == nil {
 		return
 	}
 
-	if o.Config.Interval.Max != nil {
-		config.Interval.Max = *o.Config.Interval.Max
+	if t.Interval.Max != nil {
+		config.Interval.Max = *t.Interval.Max
 	}
-	if o.Config.Interval.Min != nil {
-		config.Interval.Min = *o.Config.Interval.Min
+	if t.Interval.Min != nil {
+		config.Interval.Min = *t.Interval.Min
 	}
 }
 
-// applyScheduleOverrides applies schedule configuration overrides
-func (o *ModelOverride) applyScheduleOverrides(config *transformation.Config) {
-	if o.Config.Schedules == nil || config.Schedules == nil {
+func (t *TransformationOverride) applyScheduleOverrides(config *transformation.Config) {
+	if t.Schedules == nil || config.Schedules == nil {
 		return
 	}
 
-	if o.Config.Schedules.ForwardFill != nil {
-		config.Schedules.ForwardFill = *o.Config.Schedules.ForwardFill
+	if t.Schedules.ForwardFill != nil {
+		config.Schedules.ForwardFill = *t.Schedules.ForwardFill
 	}
-	if o.Config.Schedules.Backfill != nil {
-		config.Schedules.Backfill = *o.Config.Schedules.Backfill
+	if t.Schedules.Backfill != nil {
+		config.Schedules.Backfill = *t.Schedules.Backfill
 	}
 }
 
-// applyLimitOverrides applies limit configuration overrides
-func (o *ModelOverride) applyLimitOverrides(config *transformation.Config) {
-	if o.Config.Limits == nil {
+func (t *TransformationOverride) applyLimitOverrides(config *transformation.Config) {
+	if t.Limits == nil {
 		return
 	}
 
@@ -89,22 +185,68 @@ func (o *ModelOverride) applyLimitOverrides(config *transformation.Config) {
 		config.Limits = &transformation.LimitsConfig{}
 	}
 
-	if o.Config.Limits.Min != nil {
-		config.Limits.Min = *o.Config.Limits.Min
+	if t.Limits.Min != nil {
+		config.Limits.Min = *t.Limits.Min
 	}
-	if o.Config.Limits.Max != nil {
-		config.Limits.Max = *o.Config.Limits.Max
-	}
-}
-
-// applyTagOverrides appends additional tags to the configuration
-func (o *ModelOverride) applyTagOverrides(config *transformation.Config) {
-	if len(o.Config.Tags) > 0 {
-		config.Tags = append(config.Tags, o.Config.Tags...)
+	if t.Limits.Max != nil {
+		config.Limits.Max = *t.Limits.Max
 	}
 }
 
-// IsDisabled returns true if the model is explicitly disabled
-func (o *ModelOverride) IsDisabled() bool {
-	return o != nil && o.Enabled != nil && !*o.Enabled
+func (t *TransformationOverride) applyTagOverrides(config *transformation.Config) {
+	if len(t.Tags) > 0 {
+		config.Tags = append(config.Tags, t.Tags...)
+	}
+}
+
+// ExternalOverride contains override values for external model configurations
+// All fields are optional - nil means keep existing value
+type ExternalOverride struct {
+	Lag   *uint64        `yaml:"lag,omitempty"`
+	Cache *CacheOverride `yaml:"cache,omitempty"`
+}
+
+// CacheOverride allows overriding cache configuration
+type CacheOverride struct {
+	IncrementalScanInterval *time.Duration `yaml:"incremental_scan_interval,omitempty"`
+	FullScanInterval        *time.Duration `yaml:"full_scan_interval,omitempty"`
+}
+
+// ExternalOverride implements OverrideConfig for external models
+func (e *ExternalOverride) applyToTransformation(_ *transformation.Config) {
+	// No-op: external overrides don't apply to transformation models
+}
+
+func (e *ExternalOverride) applyToExternal(config *external.Config) {
+	e.applyLagOverride(config)
+	e.applyCacheOverride(config)
+}
+
+func (e *ExternalOverride) applyLagOverride(config *external.Config) {
+	if e.Lag != nil {
+		config.Lag = *e.Lag
+	}
+}
+
+func (e *ExternalOverride) applyCacheOverride(config *external.Config) {
+	if e.Cache == nil || config.Cache == nil {
+		return
+	}
+
+	if e.Cache.IncrementalScanInterval != nil {
+		config.Cache.IncrementalScanInterval = *e.Cache.IncrementalScanInterval
+	}
+
+	if e.Cache.FullScanInterval != nil {
+		config.Cache.FullScanInterval = *e.Cache.FullScanInterval
+	}
+}
+
+// ApplyToExternal applies override configuration to an external model
+func (m *ModelOverride) ApplyToExternal(config *external.Config) {
+	if m == nil || m.Config == nil {
+		return
+	}
+
+	m.Config.applyToExternal(config)
 }

--- a/pkg/models/service.go
+++ b/pkg/models/service.go
@@ -1,12 +1,18 @@
 package models
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/ethpandaops/cbt/pkg/clickhouse"
 	"github.com/redis/go-redis/v9"
 	"github.com/sirupsen/logrus"
+)
+
+var (
+	// ErrOverrideModelNotFound is returned when an override key doesn't match any loaded model
+	ErrOverrideModelNotFound = errors.New("no matching model found for override key")
 )
 
 // Service defines the interface for the models service (ethPandaOps pattern)
@@ -136,47 +142,172 @@ func (s *service) applyOverrides() {
 		return
 	}
 
-	// Track which overrides were applied
-	appliedOverrides := make(map[string]bool)
+	modelTypes := s.buildModelTypeMapping()
+	s.resolveAllOverrides(modelTypes)
+	appliedOverrides := s.applyOverridesToModels()
+	s.warnUnmatchedOverrides(appliedOverrides)
+}
 
-	// Filter transformations based on overrides - pre-allocate with capacity
-	filteredTransformations := make([]Transformation, 0, len(s.transformationModels))
+// buildModelTypeMapping creates a map of model IDs to their types
+func (s *service) buildModelTypeMapping() map[string]ModelType {
+	modelTypes := make(map[string]ModelType, len(s.externalModels)+len(s.transformationModels))
+
+	for _, model := range s.externalModels {
+		config := model.GetConfig()
+		modelTypes[config.GetID()] = ModelTypeExternal
+	}
+
 	for _, model := range s.transformationModels {
 		config := model.GetConfig()
-		modelID := config.GetID()
+		modelTypes[config.GetID()] = ModelTypeTransformation
+	}
 
-		// Try to find override using either full ID or table-only format
-		override, overrideKey := s.findOverride(modelID, config.Table)
+	return modelTypes
+}
+
+// resolveAllOverrides resolves the config for all overrides based on model type lookup
+func (s *service) resolveAllOverrides(modelTypes map[string]ModelType) {
+	for modelID, override := range s.config.Overrides {
+		if modelType, exists := modelTypes[modelID]; exists {
+			if err := override.ResolveConfig(modelType); err != nil {
+				s.log.WithField("model", modelID).WithError(err).Warn("Failed to resolve override config")
+			}
+		} else {
+			// Try table-only lookup with default databases
+			if resolveErr := s.resolveOverrideWithDefaults(modelID, override, modelTypes); resolveErr != nil {
+				s.log.WithField("model", modelID).Debug("Could not resolve override (will check during model iteration)")
+			}
+		}
+	}
+}
+
+// applyOverridesToModels applies overrides to both external and transformation models
+func (s *service) applyOverridesToModels() map[string]bool {
+	appliedOverrides := make(map[string]bool, len(s.config.Overrides))
+
+	s.externalModels = s.applyExternalOverrides(appliedOverrides)
+	s.transformationModels = s.applyTransformationOverrides(appliedOverrides)
+
+	return appliedOverrides
+}
+
+// applyExternalOverrides applies overrides to external models and returns filtered list
+func (s *service) applyExternalOverrides(appliedOverrides map[string]bool) []External {
+	filtered := make([]External, 0, len(s.externalModels))
+
+	for _, model := range s.externalModels {
+		if s.shouldSkipModel(model, ModelTypeExternal, appliedOverrides) {
+			continue
+		}
+		filtered = append(filtered, model)
+	}
+
+	return filtered
+}
+
+// applyTransformationOverrides applies overrides to transformation models and returns filtered list
+func (s *service) applyTransformationOverrides(appliedOverrides map[string]bool) []Transformation {
+	filtered := make([]Transformation, 0, len(s.transformationModels))
+
+	for _, model := range s.transformationModels {
+		if s.shouldSkipModel(model, ModelTypeTransformation, appliedOverrides) {
+			continue
+		}
+		filtered = append(filtered, model)
+	}
+
+	return filtered
+}
+
+// shouldSkipModel checks if a model should be skipped and applies overrides if found
+func (s *service) shouldSkipModel(model interface{}, modelType ModelType, appliedOverrides map[string]bool) bool {
+	var modelID, tableName string
+	var override *ModelOverride
+	var overrideKey string
+
+	switch modelType {
+	case ModelTypeExternal:
+		extModel, ok := model.(External)
+		if !ok {
+			return false
+		}
+		config := extModel.GetConfig()
+		modelID = config.GetID()
+		tableName = config.Table
+		override, overrideKey = s.findOverride(modelID, tableName, ModelTypeExternal)
 
 		if override != nil {
 			appliedOverrides[overrideKey] = true
 
-			// Check if model is disabled
 			if override.IsDisabled() {
-				s.log.WithField("model", modelID).Info("Model disabled by override")
-				continue // Skip this model
+				s.log.WithField("model", modelID).Info("External model disabled by override")
+				return true
 			}
 
-			// Apply configuration overrides
-			override.ApplyToTransformation(config)
-			s.log.WithField("model", modelID).Debug("Applied configuration override")
+			mutableConfig := extModel.GetConfigMutable()
+			override.ApplyToExternal(mutableConfig)
+			s.log.WithField("model", modelID).Debug("Applied external configuration override")
 		}
 
-		filteredTransformations = append(filteredTransformations, model)
+	case ModelTypeTransformation:
+		transModel, ok := model.(Transformation)
+		if !ok {
+			return false
+		}
+		config := transModel.GetConfig()
+		modelID = config.GetID()
+		tableName = config.Table
+		override, overrideKey = s.findOverride(modelID, tableName, ModelTypeTransformation)
+
+		if override != nil {
+			appliedOverrides[overrideKey] = true
+
+			if override.IsDisabled() {
+				s.log.WithField("model", modelID).Info("Transformation model disabled by override")
+				return true
+			}
+
+			override.ApplyToTransformation(config)
+			s.log.WithField("model", modelID).Debug("Applied transformation configuration override")
+		}
 	}
 
-	// Warn about overrides that didn't match any models
+	return false
+}
+
+// warnUnmatchedOverrides logs warnings for overrides that didn't match any models
+func (s *service) warnUnmatchedOverrides(appliedOverrides map[string]bool) {
 	for modelID := range s.config.Overrides {
 		if !appliedOverrides[modelID] {
 			s.log.WithField("model", modelID).Warn("Override specified for non-existent model")
 		}
 	}
+}
 
-	s.transformationModels = filteredTransformations
+// resolveOverrideWithDefaults attempts to resolve an override using default database lookup
+func (s *service) resolveOverrideWithDefaults(overrideKey string, override *ModelOverride, modelTypes map[string]ModelType) error {
+	// Check if this could be a table-only key
+	// Try with external default database
+	if s.config.External.DefaultDatabase != "" {
+		fullID := fmt.Sprintf("%s.%s", s.config.External.DefaultDatabase, overrideKey)
+		if modelType, exists := modelTypes[fullID]; exists {
+			return override.ResolveConfig(modelType)
+		}
+	}
+
+	// Try with transformation default database
+	if s.config.Transformation.DefaultDatabase != "" {
+		fullID := fmt.Sprintf("%s.%s", s.config.Transformation.DefaultDatabase, overrideKey)
+		if modelType, exists := modelTypes[fullID]; exists {
+			return override.ResolveConfig(modelType)
+		}
+	}
+
+	return fmt.Errorf("%w: %s", ErrOverrideModelNotFound, overrideKey)
 }
 
 // findOverride looks up an override using both full ID and table-only formats
-func (s *service) findOverride(fullID, tableName string) (override *ModelOverride, overrideKey string) {
+func (s *service) findOverride(fullID, tableName string, modelType ModelType) (override *ModelOverride, overrideKey string) {
 	// First, try with the full model ID (database.table)
 	if override, exists := s.config.Overrides[fullID]; exists {
 		return override, fullID
@@ -184,9 +315,16 @@ func (s *service) findOverride(fullID, tableName string) (override *ModelOverrid
 
 	// If the model uses the default database, also try with just the table name
 	// This allows more intuitive overrides when using default databases
-	if s.config.Transformation.DefaultDatabase != "" {
+	var defaultDatabase string
+	if modelType == ModelTypeExternal {
+		defaultDatabase = s.config.External.DefaultDatabase
+	} else {
+		defaultDatabase = s.config.Transformation.DefaultDatabase
+	}
+
+	if defaultDatabase != "" {
 		// Check if this model is using the default database
-		if fullID == fmt.Sprintf("%s.%s", s.config.Transformation.DefaultDatabase, tableName) {
+		if fullID == fmt.Sprintf("%s.%s", defaultDatabase, tableName) {
 			if override, exists := s.config.Overrides[tableName]; exists {
 				return override, tableName
 			}

--- a/pkg/models/template_test.go
+++ b/pkg/models/template_test.go
@@ -39,12 +39,13 @@ type mockExternalWithTemplate struct {
 	value  string
 }
 
-func (m *mockExternalWithTemplate) GetID() string                     { return m.id }
-func (m *mockExternalWithTemplate) GetConfig() external.Config        { return m.config }
-func (m *mockExternalWithTemplate) GetType() string                   { return m.typ }
-func (m *mockExternalWithTemplate) GetSQL() string                    { return "" }
-func (m *mockExternalWithTemplate) GetValue() string                  { return m.value }
-func (m *mockExternalWithTemplate) GetEnvironmentVariables() []string { return []string{} }
+func (m *mockExternalWithTemplate) GetID() string                      { return m.id }
+func (m *mockExternalWithTemplate) GetConfig() external.Config         { return m.config }
+func (m *mockExternalWithTemplate) GetConfigMutable() *external.Config { return &m.config }
+func (m *mockExternalWithTemplate) GetType() string                    { return m.typ }
+func (m *mockExternalWithTemplate) GetSQL() string                     { return "" }
+func (m *mockExternalWithTemplate) GetValue() string                   { return m.value }
+func (m *mockExternalWithTemplate) GetEnvironmentVariables() []string  { return []string{} }
 func (m *mockExternalWithTemplate) SetDefaultDatabase(defaultDB string) {
 	m.config.SetDefaults(defaultDB)
 }

--- a/pkg/validation/external_test.go
+++ b/pkg/validation/external_test.go
@@ -196,6 +196,10 @@ func (a *externalModelAdapter) GetConfig() external.Config {
 	return a.testModel.GetConfig()
 }
 
+func (a *externalModelAdapter) GetConfigMutable() *external.Config {
+	return &a.testModel.config
+}
+
 func (a *externalModelAdapter) GetType() string {
 	return a.testModel.GetType()
 }

--- a/pkg/validation/validator_test.go
+++ b/pkg/validation/validator_test.go
@@ -945,6 +945,13 @@ func (m *mockExternal) GetConfig() external.Config {
 		Table:    "test",
 	}
 }
+func (m *mockExternal) GetConfigMutable() *external.Config {
+	config := external.Config{
+		Database: "test",
+		Table:    "test",
+	}
+	return &config
+}
 func (m *mockExternal) GetValue() string { return "" }
 func (m *mockExternal) GetType() string  { return "sql" }
 func (m *mockExternal) SetDefaultDatabase(_ string) {

--- a/pkg/worker/executor_test.go
+++ b/pkg/worker/executor_test.go
@@ -601,10 +601,11 @@ type mockExternal struct {
 	typ  string
 }
 
-func (m *mockExternal) GetID() string              { return m.id }
-func (m *mockExternal) GetConfig() external.Config { return m.conf }
-func (m *mockExternal) GetValue() string           { return m.val }
-func (m *mockExternal) GetType() string            { return m.typ }
+func (m *mockExternal) GetID() string                      { return m.id }
+func (m *mockExternal) GetConfig() external.Config         { return m.conf }
+func (m *mockExternal) GetConfigMutable() *external.Config { return &m.conf }
+func (m *mockExternal) GetValue() string                   { return m.val }
+func (m *mockExternal) GetType() string                    { return m.typ }
 func (m *mockExternal) SetDefaultDatabase(defaultDB string) {
 	if m.conf.Database == "" {
 		m.conf.Database = defaultDB


### PR DESCRIPTION
Add support for overriding external model configurations (lag, cache intervals) using a two-pass unmarshaling approach with automatic model type detection.

Key changes:
- Add ExternalOverride and CacheOverride structs for external model config
- Implement ModelOverride with polymorphic OverrideConfig interface
- Add GetConfigMutable() to External interface for mutable config access
- Service resolves override types by looking up loaded models
- Always use 'config' field in YAML, system determines type automatically
- Refactor applyOverrides() to reduce cyclomatic complexity (16 -> 4)
- Add comprehensive tests for external overrides
- Fix all mock implementations to include GetConfigMutable()

Usage:
overrides:
  mainnet.beacon_api_eth_v1_events_attestation: config: lag: 60 cache: incremental_scan_interval: 10s full_scan_interval: 48h