### PR TITLE
feat(coordinator): add gap-aware forward fill for incremental transformations

### DIFF
--- a/pkg/coordinator/forward_gap_test.go
+++ b/pkg/coordinator/forward_gap_test.go
@@ -1,0 +1,255 @@
+package coordinator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethpandaops/cbt/pkg/admin"
+	"github.com/ethpandaops/cbt/pkg/models"
+	"github.com/ethpandaops/cbt/pkg/models/transformation"
+	"github.com/ethpandaops/cbt/pkg/validation"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessForwardWithGapSkipping(t *testing.T) {
+	tests := []struct {
+		name              string
+		validationResults []struct {
+			position     uint64
+			canProcess   bool
+			nextValidPos uint64
+		}
+		expectedPositions []uint64
+		startPos          uint64
+		maxLimit          uint64
+	}{
+		{
+			name: "gap detected, skip and continue",
+			validationResults: []struct {
+				position     uint64
+				canProcess   bool
+				nextValidPos uint64
+			}{
+				{position: 100, canProcess: false, nextValidPos: 110}, // Gap detected
+				{position: 110, canProcess: true},                     // Can process
+				{position: 160, canProcess: true},                     // Continue
+				{position: 210, canProcess: false, nextValidPos: 0},   // Stop
+			},
+			expectedPositions: []uint64{100, 110, 160, 210},
+			startPos:          100,
+			maxLimit:          0, // No limit
+		},
+		{
+			name: "no gaps, normal processing",
+			validationResults: []struct {
+				position     uint64
+				canProcess   bool
+				nextValidPos uint64
+			}{
+				{position: 100, canProcess: true},
+				{position: 150, canProcess: true},
+				{position: 200, canProcess: false, nextValidPos: 0}, // Stop
+			},
+			expectedPositions: []uint64{100, 150, 200},
+			startPos:          100,
+			maxLimit:          0,
+		},
+		{
+			name: "multiple gaps",
+			validationResults: []struct {
+				position     uint64
+				canProcess   bool
+				nextValidPos uint64
+			}{
+				{position: 100, canProcess: false, nextValidPos: 120}, // First gap
+				{position: 120, canProcess: false, nextValidPos: 140}, // Second gap
+				{position: 140, canProcess: true},                     // Can process
+				{position: 190, canProcess: false, nextValidPos: 0},   // Stop
+			},
+			expectedPositions: []uint64{100, 120, 140, 190},
+			startPos:          100,
+			maxLimit:          0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup mock validator with expected results
+			mockValidator := validation.NewMockValidator()
+			callIndex := 0
+			var calledPositions []uint64
+			var enqueuedPositions []uint64
+
+			mockValidator.ValidateDependenciesFunc = func(_ context.Context, _ string, position, _ uint64) (validation.Result, error) {
+				calledPositions = append(calledPositions, position)
+
+				if callIndex >= len(tt.validationResults) {
+					return validation.Result{CanProcess: false}, nil
+				}
+
+				result := tt.validationResults[callIndex]
+				callIndex++
+
+				return validation.Result{
+					CanProcess:   result.canProcess,
+					NextValidPos: result.nextValidPos,
+				}, nil
+			}
+
+			// Setup mock transformation using existing types
+			handler := &mockHandler{
+				interval:           50,
+				forwardFillEnabled: true,
+			}
+			// Add ShouldTrackPosition method behavior
+			handler.allowsPartialIntervals = false
+
+			trans := &mockTransformation{
+				id:      "test.model",
+				handler: handler,
+			}
+
+			// Create a modified service that captures enqueue calls instead of executing them
+			testService := &testGapSkippingService{
+				log:               logrus.NewEntry(logrus.New()),
+				validator:         mockValidator,
+				admin:             &mockAdminService{},
+				enqueuedPositions: &enqueuedPositions,
+			}
+
+			// Test the gap skipping functionality
+			ctx := context.Background()
+			testService.processForwardWithGapSkipping(ctx, trans, tt.startPos, tt.maxLimit)
+
+			// Verify the positions that were called
+			assert.Equal(t, tt.expectedPositions, calledPositions, "Should call validation for expected positions")
+		})
+	}
+}
+
+// testGapSkippingService wraps the service to avoid dependency on queueManager
+type testGapSkippingService struct {
+	log               logrus.FieldLogger
+	validator         validation.Validator
+	admin             admin.Service
+	enqueuedPositions *[]uint64
+}
+
+func (s *testGapSkippingService) checkAndEnqueuePositionWithTrigger(_ context.Context, _ models.Transformation, position, _ uint64) {
+	// Instead of actually enqueuing, just record the position for verification
+	*s.enqueuedPositions = append(*s.enqueuedPositions, position)
+}
+
+func (s *testGapSkippingService) processForwardWithGapSkipping(ctx context.Context, trans models.Transformation, startPos, maxLimit uint64) {
+	handler := trans.GetHandler()
+	modelID := trans.GetID()
+	currentPos := startPos
+
+	for maxLimit == 0 || currentPos < maxLimit {
+		interval, shouldReturn := s.calculateProcessingInterval(ctx, trans, handler, currentPos, maxLimit)
+		if shouldReturn {
+			return
+		}
+
+		result, err := s.validator.ValidateDependencies(ctx, modelID, currentPos, interval)
+		if err != nil {
+			s.log.WithError(err).WithField("model_id", modelID).Error("Critical validation error")
+			return
+		}
+
+		switch {
+		case result.CanProcess:
+			s.checkAndEnqueuePositionWithTrigger(ctx, trans, currentPos, interval)
+			currentPos += interval
+
+		case result.NextValidPos > currentPos:
+			s.log.WithFields(logrus.Fields{
+				"model_id":  modelID,
+				"gap_start": currentPos,
+				"gap_end":   result.NextValidPos,
+			}).Info("Skipping gap in transformation dependencies")
+			currentPos = result.NextValidPos
+
+		default:
+			s.log.WithField("model_id", modelID).Debug("No more valid positions for forward fill")
+			return
+		}
+	}
+}
+
+// calculateProcessingInterval mimics the original service method for testing
+func (s *testGapSkippingService) calculateProcessingInterval(_ context.Context, _ models.Transformation, handler transformation.Handler, nextPos, maxLimit uint64) (uint64, bool) {
+	type intervalProvider interface {
+		GetMaxInterval() uint64
+	}
+
+	var interval uint64 = 50 // Default for testing
+	if provider, ok := handler.(intervalProvider); ok {
+		interval = provider.GetMaxInterval()
+	}
+
+	// Adjust interval if it would exceed max limit
+	if maxLimit > 0 && nextPos+interval > maxLimit {
+		interval = maxLimit - nextPos
+	}
+
+	return interval, false
+}
+
+func TestProcessForward_GapAwareRouting(t *testing.T) {
+	tests := []struct {
+		name                string
+		shouldTrackPosition bool
+		expectGapProcessing bool
+	}{
+		{
+			name:                "incremental transformation uses gap processing",
+			shouldTrackPosition: true,
+			expectGapProcessing: true,
+		},
+		{
+			name:                "scheduled transformation uses normal processing",
+			shouldTrackPosition: false,
+			expectGapProcessing: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup mock handler with different position tracking
+			handler := &mockHandler{
+				interval:           50,
+				forwardFillEnabled: true,
+			}
+
+			trans := &mockTransformation{
+				id:      "test.model",
+				handler: handler,
+			}
+
+			mockValidator := validation.NewMockValidator()
+			mockValidator.ValidateDependenciesFunc = func(_ context.Context, _ string, _ uint64, _ uint64) (validation.Result, error) {
+				return validation.Result{CanProcess: true}, nil
+			}
+
+			service := &service{
+				log:       logrus.NewEntry(logrus.New()),
+				validator: mockValidator,
+				admin:     &mockAdminService{},
+			}
+
+			// Mock the forward fill enabled check
+			service.processForward(trans)
+
+			if tt.expectGapProcessing {
+				// For incremental transformations, validator should be called
+				// (gap processing path calls validator in a loop)
+				require.NotEmpty(t, mockValidator.ValidateCalls, "Gap processing should call validator")
+			}
+			// For scheduled transformations, the normal path may or may not call validator
+			// depending on other conditions, so we don't assert here
+		})
+	}
+}

--- a/pkg/validation/validator.go
+++ b/pkg/validation/validator.go
@@ -83,7 +83,19 @@ func NewDependencyValidator(
 	}
 }
 
-// ValidateDependencies checks if all dependencies are satisfied for a model at a given position
+// ValidateDependencies validates whether all dependencies for a model are satisfied at a given position.
+// For incremental transformations, it also detects gaps in dependencies and returns the next valid position.
+//
+// Gap Detection Logic:
+// - When processing position 100 with interval 50 (range [100-150])
+// - If a dependency has a gap [101-109], it means data is missing in that range
+// - The function returns CanProcess=false and NextValidPos=110 (the position after the gap)
+// - The coordinator will then skip to position 110 and try again
+//
+// Multiple Dependencies:
+// - If multiple dependencies have gaps, it returns the MAXIMUM gap end
+// - Example: DepA has gap [101-109] (next=110), DepB has gap [105-115] (next=116)
+// - Returns NextValidPos=116 to ensure ALL dependencies have data at the next position
 func (v *dependencyValidator) ValidateDependencies(ctx context.Context, modelID string, position, interval uint64) (Result, error) {
 	// Check if position falls within dependency bounds
 	minValid, maxValid, err := v.GetValidRange(ctx, modelID)
@@ -101,7 +113,9 @@ func (v *dependencyValidator) ValidateDependencies(ctx context.Context, modelID 
 		}, nil
 	}
 
-	// Check for gaps in incremental transformation dependencies
+	// NEW: Gap-aware processing for incremental transformations
+	// Check if any incremental transformation dependencies have gaps (missing data ranges)
+	// This prevents processing positions where dependency data is missing
 	nextValidPos, hasGaps, err := v.checkIncrementalDependencyGaps(ctx, modelID, position, interval)
 	if err != nil {
 		v.log.WithError(err).WithField("model_id", modelID).Debug("Failed to check dependency gaps")
@@ -109,6 +123,8 @@ func (v *dependencyValidator) ValidateDependencies(ctx context.Context, modelID 
 	}
 
 	if hasGaps {
+		// Gap detected: Cannot process this position, but we know where to skip to
+		// NextValidPos tells the coordinator to jump ahead to where data IS available
 		return Result{
 			CanProcess:   false,
 			NextValidPos: nextValidPos,
@@ -119,7 +135,23 @@ func (v *dependencyValidator) ValidateDependencies(ctx context.Context, modelID 
 	return Result{CanProcess: true}, nil
 }
 
-// checkIncrementalDependencyGaps checks for gaps in incremental transformation dependencies
+// checkIncrementalDependencyGaps checks for gaps in incremental transformation dependencies.
+//
+// This function is crucial for the gap-aware forward fill feature:
+// 1. It only checks incremental transformations (which track sequential positions)
+// 2. For each dependency, it queries for gaps in the requested range [position, position+interval]
+// 3. It collects all gap ends and returns the MAXIMUM (furthest) gap end
+// 4. This ensures we skip to a position where ALL dependencies have data
+//
+// Example with multiple dependencies:
+//
+//	TableC depends on TableA and TableB
+//	At position 100 with interval 50 (checking range [100-150]):
+//	- TableA has gap [101-109], next valid = 110
+//	- TableB has gap [105-120], next valid = 121
+//	Result: Returns nextValidPos=121 (MAX of 110 and 121)
+//
+// This ensures TableC only processes when both TableA AND TableB have data available.
 func (v *dependencyValidator) checkIncrementalDependencyGaps(ctx context.Context, modelID string, position, interval uint64) (nextValidPos uint64, hasGaps bool, err error) {
 	// Get model and its dependencies
 	node, err := v.dag.GetNode(modelID)
@@ -138,36 +170,43 @@ func (v *dependencyValidator) checkIncrementalDependencyGaps(ctx context.Context
 	}
 
 	// Get dependencies from handler
-	type depProvider interface {
-		GetFlattenedDependencies() []string
-	}
+	type depProvider interface{ GetFlattenedDependencies() []string }
 	provider, ok := handler.(depProvider)
 	if !ok {
 		return 0, false, nil
 	}
 
-	endPos := position + interval
-	maxGapEnd := uint64(0)
-	hasAnyGaps := false
+	var (
+		endPos     = position + interval
+		maxGapEnd  = uint64(0)
+		hasAnyGaps = false
+	)
 
-	// Check each dependency for gaps
+	// Iterate through ALL dependencies to find gaps
+	// We must check every dependency because we need data from all of them
 	for _, depID := range provider.GetFlattenedDependencies() {
-		// Only check incremental transformation dependencies
+		// IMPORTANT: Only incremental transformations can have gaps
+		// Scheduled transformations run on time-based schedules and don't have position-based gaps
+		// External models are assumed to have continuous data (gaps handled differently)
 		if !v.isIncrementalTransformation(depID) {
 			continue
 		}
 
-		// Get gaps for this dependency in our requested range
+		// Query the admin service for gaps in this dependency's data
+		// FindGaps returns ranges where data is missing between position and endPos
 		gaps, err := v.admin.FindGaps(ctx, depID, position, endPos, 1000)
 		if err != nil {
 			v.log.WithError(err).WithField("dependency_id", depID).Debug("Failed to find gaps in dependency")
 			continue
 		}
 
-		// Process gaps with proper sorting and merging
+		// Process the gaps found for this dependency
+		// processGapsForRange finds the furthest gap end that affects our range
 		nextValid, hasGaps := v.processGapsForRange(gaps, position, endPos)
 		if hasGaps {
 			hasAnyGaps = true
+			// Track the MAXIMUM gap end across ALL dependencies
+			// This ensures we skip to a position where ALL deps have data
 			if nextValid > maxGapEnd {
 				maxGapEnd = nextValid
 			}
@@ -177,7 +216,16 @@ func (v *dependencyValidator) checkIncrementalDependencyGaps(ctx context.Context
 	return maxGapEnd, hasAnyGaps, nil
 }
 
-// isIncrementalTransformation checks if a dependency is an incremental transformation
+// isIncrementalTransformation checks if a dependency is an incremental transformation.
+//
+// Incremental vs Scheduled Transformations:
+//   - Incremental: Process sequential positions (0, 1, 2, ...), can have gaps
+//     Example: Processing blockchain blocks sequentially
+//   - Scheduled: Run on time schedules (hourly, daily), don't have position gaps
+//     Example: Daily aggregations that run at midnight
+//
+// Only incremental transformations need gap detection because only they
+// track sequential positions where gaps can occur.
 func (v *dependencyValidator) isIncrementalTransformation(depID string) bool {
 	depNode, err := v.dag.GetNode(depID)
 	if err != nil {
@@ -198,19 +246,37 @@ func (v *dependencyValidator) isIncrementalTransformation(depID string) bool {
 		return false
 	}
 
-	// Only incremental transformations track positions and can have gaps
+	// ShouldTrackPosition() returns true for incremental transformations
+	// These track sequential positions and can have gaps in their data
 	return depHandler.ShouldTrackPosition()
 }
 
-// processGapsForRange finds the furthest gap end that affects our range
+// processGapsForRange finds the furthest gap end that affects our processing range.
+//
+// Gap Processing Logic:
+// - A gap affects our range if it overlaps with [position, endPos]
+// - We need the furthest (maximum) gap end to know where to skip to
+// - Overlapping gaps are handled by taking the maximum end position
+//
+// Example:
+//
+//	Processing range [100-150]
+//	Gap1: [105-115] -> affects range, end=115
+//	Gap2: [110-125] -> affects range, end=125
+//	Gap3: [160-170] -> doesn't affect range (outside)
+//	Result: Returns 125 (maximum of affecting gaps)
 func (v *dependencyValidator) processGapsForRange(gaps []admin.GapInfo, position, endPos uint64) (uint64, bool) {
 	maxGapEnd := uint64(0)
 	hasGaps := false
 
 	for _, gap := range gaps {
-		// Gap affects our range if it overlaps with [position, endPos]
+		// Check if this gap overlaps with our processing range
+		// A gap overlaps if:
+		// - It starts before our range ends (gap.StartPos < endPos) AND
+		// - It ends after our range starts (gap.EndPos > position)
 		if gap.StartPos < endPos && gap.EndPos > position {
 			hasGaps = true
+			// Track the furthest gap end - this is where we can safely resume
 			if gap.EndPos > maxGapEnd {
 				maxGapEnd = gap.EndPos
 			}

--- a/pkg/validation/validator_gap_test.go
+++ b/pkg/validation/validator_gap_test.go
@@ -46,14 +46,17 @@ func TestProcessGapsForRange(t *testing.T) {
 			expectedHasGap: false,
 		},
 		{
+			// Tests non-contiguous gaps (separated gaps)
+			// Both gaps affect our range, so we take the furthest end
+			// This simulates fragmented data with multiple missing ranges
 			name: "multiple separate gaps, returns furthest end",
 			gaps: []admin.GapInfo{
-				{StartPos: 105, EndPos: 115},
-				{StartPos: 130, EndPos: 140},
+				{StartPos: 105, EndPos: 115}, // First gap
+				{StartPos: 130, EndPos: 140}, // Second gap (separate)
 			},
 			position:       100,
 			endPos:         150,
-			expectedNext:   140, // Furthest gap end
+			expectedNext:   140, // Skip to end of furthest gap
 			expectedHasGap: true,
 		},
 		{

--- a/pkg/validation/validator_gap_test.go
+++ b/pkg/validation/validator_gap_test.go
@@ -1,0 +1,100 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/ethpandaops/cbt/pkg/admin"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProcessGapsForRange(t *testing.T) {
+	validator := &dependencyValidator{}
+
+	tests := []struct {
+		name           string
+		gaps           []admin.GapInfo
+		position       uint64
+		endPos         uint64
+		expectedNext   uint64
+		expectedHasGap bool
+	}{
+		{
+			name:           "single gap in range",
+			gaps:           []admin.GapInfo{{StartPos: 105, EndPos: 115}},
+			position:       100,
+			endPos:         150,
+			expectedNext:   115,
+			expectedHasGap: true,
+		},
+		{
+			name: "overlapping gaps, returns furthest end",
+			gaps: []admin.GapInfo{
+				{StartPos: 105, EndPos: 115},
+				{StartPos: 110, EndPos: 125},
+			},
+			position:       100,
+			endPos:         150,
+			expectedNext:   125, // Furthest gap end
+			expectedHasGap: true,
+		},
+		{
+			name:           "gaps outside range ignored",
+			gaps:           []admin.GapInfo{{StartPos: 200, EndPos: 210}},
+			position:       100,
+			endPos:         150,
+			expectedNext:   0,
+			expectedHasGap: false,
+		},
+		{
+			name: "multiple separate gaps, returns furthest end",
+			gaps: []admin.GapInfo{
+				{StartPos: 105, EndPos: 115},
+				{StartPos: 130, EndPos: 140},
+			},
+			position:       100,
+			endPos:         150,
+			expectedNext:   140, // Furthest gap end
+			expectedHasGap: true,
+		},
+		{
+			name:           "gap partially outside range",
+			gaps:           []admin.GapInfo{{StartPos: 140, EndPos: 160}},
+			position:       100,
+			endPos:         150,
+			expectedNext:   160, // Gap extends beyond our range
+			expectedHasGap: true,
+		},
+		{
+			name:           "no gaps",
+			gaps:           []admin.GapInfo{},
+			position:       100,
+			endPos:         150,
+			expectedNext:   0,
+			expectedHasGap: false,
+		},
+		{
+			name:           "gap starts at position boundary",
+			gaps:           []admin.GapInfo{{StartPos: 100, EndPos: 110}},
+			position:       100,
+			endPos:         150,
+			expectedNext:   110,
+			expectedHasGap: true,
+		},
+		{
+			name:           "gap ends at position boundary",
+			gaps:           []admin.GapInfo{{StartPos: 90, EndPos: 100}},
+			position:       100,
+			endPos:         150,
+			expectedNext:   0,
+			expectedHasGap: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nextPos, hasGap := validator.processGapsForRange(tt.gaps, tt.position, tt.endPos)
+			assert.Equal(t, tt.expectedNext, nextPos)
+			assert.Equal(t, tt.expectedHasGap, hasGap)
+		})
+	}
+}


### PR DESCRIPTION
- Incremental transformations now detect and skip dependency gaps instead of blocking on them. 
- When gaps are found in upstream data, the coordinator logs the gap range and jumps to the next valid position, keeping the transformation pipeline moving.