### PR TITLE
feat: add support for custom environment variables in scripted transformations

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,11 +571,43 @@ Models can execute external scripts instead of SQL. The script receives environm
 #### Environment Variables
 
 Environment variables provided to scripts:
+
+**Built-in variables:**
 - `CLICKHOUSE_URL`: Connection URL (e.g., `clickhouse://host:9000`)
-- `BOUNDS_START`, `BOUNDS_END`: Bounds for processing
-- `TASK_START`: Task execution timestamp
+- `CLICKHOUSE_CLUSTER`: ClickHouse cluster name (if configured)
+- `CLICKHOUSE_LOCAL_SUFFIX`: Local table suffix for cluster setups (if configured)
+- `BOUNDS_START`, `BOUNDS_END`: Bounds for processing (incremental only)
+- `TASK_START`: Task execution timestamp (Unix)
+- `TASK_MODEL`: Full model identifier (database.table)
+- `TASK_INTERVAL`: Interval size being processed (incremental only)
 - `SELF_DATABASE`, `SELF_TABLE`: Target table info
-- `DEP_<MODEL>_DATABASE`, `DEP_<MODEL>_TABLE`: Dependency info
+- `DEP_<MODEL>_DATABASE`, `DEP_<MODEL>_TABLE`: Dependency info (uppercase, dots/hyphens → underscores)
+
+**Custom environment variables:**
+
+You can define custom environment variables at two levels:
+
+1. **Global level** (config.yaml) - applies to all transformations:
+```yaml
+models:
+  transformations:
+    env:
+      API_KEY: "your_api_key"
+      ENVIRONMENT: "production"
+      CUSTOM_SETTING: "value"
+```
+
+2. **Transformation level** (model YAML) - overrides global variables:
+```yaml
+type: incremental
+table: my_model
+exec: "python3 /app/scripts/process.py"
+env:
+  API_KEY: "model_specific_key"  # Overrides global
+  MODEL_PARAM: "specific_value"   # Model-specific only
+```
+
+Custom variables are passed to your script alongside built-in variables. Transformation-level variables take precedence over global variables with the same name
 
 #### Example
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -88,3 +88,7 @@ worker:
 #     paths:
 #       - "models/transformations" # default
 #       - "/additional/transformation/models"
+#     # Optional: Global custom environment variables for all transformations
+#     env:
+#       API_KEY: "your_api_key_here"
+#       ENVIRONMENT: "production"

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -60,6 +60,10 @@ models:
     paths:
       - "/app/models/transformations"
     defaultDatabase: "analytics"  # Default database for transformation models
+    # Optional: Global custom environment variables for all transformations
+    env:
+      API_KEY: "global_api_key_12345"
+      ENVIRONMENT: "development"
 
 # Optional: Override configuration for specific transformation models
 # Useful for environment-specific adjustments (staging, production, etc.)

--- a/example/models/transformations/entities/entity_changes.yml
+++ b/example/models/transformations/entities/entity_changes.yml
@@ -15,3 +15,8 @@ tags:
 dependencies:
   - "{{external}}.validator_entity"
 exec: "python3 /app/scripts/entity_changes.py"
+# Optional: Transformation-specific environment variables
+# These override global env vars from config.yaml
+env:
+  API_KEY: "entity_changes_override_key"
+  CUSTOM_PARAM: "entity_specific_value_xyz"

--- a/example/scripts/entity_changes.py
+++ b/example/scripts/entity_changes.py
@@ -52,29 +52,38 @@ def execute_clickhouse_query(host, query):
 def main():
     # Get environment variables provided by CBT worker
     ch_url = os.environ['CLICKHOUSE_URL']
-    
+
     # Parse to get hostname (ignore port since we'll use 8123 for HTTP)
     parsed = urlparse(ch_url)
     ch_host = parsed.hostname or 'clickhouse'
-    
+
     # Task context
     bounds_start = int(os.environ['BOUNDS_START'])
     bounds_end = int(os.environ['BOUNDS_END'])
     task_start = int(os.environ['TASK_START'])
-    
+
     # Model info
     target_db = os.environ['SELF_DATABASE']
     target_table = os.environ['SELF_TABLE']
-    
+
     # Dependency info
     dep_db = os.environ.get('DEP_ETHEREUM_VALIDATOR_ENTITY_DATABASE', 'ethereum')
     dep_table = os.environ.get('DEP_ETHEREUM_VALIDATOR_ENTITY_TABLE', 'validator_entity')
-    
+
+    # Custom environment variables (example)
+    api_key = os.environ.get('API_KEY', 'not_set')
+    environment = os.environ.get('ENVIRONMENT', 'not_set')
+    custom_param = os.environ.get('CUSTOM_PARAM', 'not_set')
+
     print(f"=== Python Transformation Model Execution ===")
     print(f"Time range: {datetime.fromtimestamp(bounds_start)} to {datetime.fromtimestamp(bounds_end)}")
     print(f"Source: {dep_db}.{dep_table}")
     print(f"Target: {target_db}.{target_table}")
     print(f"ClickHouse host: {ch_host}")
+    print(f"\n=== Custom Environment Variables ===")
+    print(f"API_KEY: {api_key}")
+    print(f"ENVIRONMENT: {environment}")
+    print(f"CUSTOM_PARAM: {custom_param}")
     
     try:
         # Create target table if it doesn't exist

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -15,8 +15,9 @@ type ExternalConfig struct {
 
 // TransformationConfig defines configuration for transformation models
 type TransformationConfig struct {
-	Paths           []string `yaml:"paths"`
-	DefaultDatabase string   `yaml:"defaultDatabase"`
+	Paths           []string          `yaml:"paths"`
+	DefaultDatabase string            `yaml:"defaultDatabase"`
+	Env             map[string]string `yaml:"env,omitempty"`
 }
 
 // Validate validates and sets defaults for the configuration

--- a/pkg/models/service.go
+++ b/pkg/models/service.go
@@ -389,7 +389,7 @@ func (s *service) RenderTransformation(model Transformation, position, interval 
 
 // GetTransformationEnvironmentVariables returns environment variables for a transformation
 func (s *service) GetTransformationEnvironmentVariables(model Transformation, position, interval uint64, startTime time.Time) (*[]string, error) {
-	return s.templateEngine.GetTransformationEnvironmentVariables(model, position, interval, startTime)
+	return s.templateEngine.GetTransformationEnvironmentVariables(model, position, interval, startTime, s.config.Transformation.Env)
 }
 
 // RenderExternal renders an external model template with variables

--- a/pkg/models/transformation/config.go
+++ b/pkg/models/transformation/config.go
@@ -27,9 +27,10 @@ var (
 // Config is the minimal configuration used to determine the transformation type
 // Each type has its own complete configuration structure
 type Config struct {
-	Type     Type   `yaml:"type"`     // Required: "incremental" or "scheduled"
-	Database string `yaml:"database"` // Optional, can fall back to default
-	Table    string `yaml:"table"`    // Required
+	Type     Type              `yaml:"type"`     // Required: "incremental" or "scheduled"
+	Database string            `yaml:"database"` // Optional, can fall back to default
+	Table    string            `yaml:"table"`    // Required
+	Env      map[string]string `yaml:"env,omitempty"`
 }
 
 // Validate checks if the base configuration is valid


### PR DESCRIPTION
This change enables users to pass custom environment variables to scripted transformations at both global and per-transformation levels.

Changes:
- Add Env map[string]string to TransformationConfig (global level)
- Add Env map[string]string to transformation.Config (per-transformation level)
- Update GetTransformationEnvironmentVariables to accept and merge global env vars
- Transformation-specific env vars override global env vars with the same name
- Update template engine to pass globalEnv from config to env var builder
- Add comprehensive tests for custom env var functionality
- Update README.md with documentation on custom env vars
- Add example configurations in config.example.yaml and entity_changes.yml
- Update entity_changes.py example script to print custom env vars

Environment variables are now merged in this order:
1. Built-in variables (CLICKHOUSE_URL, SELF_DATABASE, etc.)
2. Global custom variables (from config.yaml)
3. Transformation-specific variables (from model YAML, overrides global)

This allows users to configure API keys, environment settings, and other custom parameters needed by their transformation scripts.