### PR TITLE
test: migrate scheduler and coordinator tests to use miniredis

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/alicebob/miniredis/v2 v2.35.0
 	github.com/creasty/defaults v1.8.0
 	github.com/getkin/kin-openapi v0.133.0
-	github.com/gofiber/fiber/v2 v2.52.9
 	github.com/gofiber/fiber/v3 v3.0.0-rc.2
 	github.com/google/uuid v1.6.0
 	github.com/heimdalr/dag v1.5.0
@@ -44,7 +43,6 @@ require (
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
@@ -57,7 +55,6 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.65.0 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
-	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/spf13/cast v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,6 @@ github.com/go-openapi/swag v0.23.0 h1:vsEVJDUo2hPJ2tu0/Xc+4noaxyEffXNIs3cOULZ+Gr
 github.com/go-openapi/swag v0.23.0/go.mod h1:esZ8ITTYEsH1V2trKHjAN8Ai7xHb8RV+YSZ577vPjgQ=
 github.com/go-test/deep v1.1.0 h1:WOcxcdHcvdgThNXjw0t76K42FXTU7HpNQWHpA2HHNlg=
 github.com/go-test/deep v1.1.0/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
-github.com/gofiber/fiber/v2 v2.52.9 h1:YjKl5DOiyP3j0mO61u3NTmK7or8GzzWzCFzkboyP5cw=
-github.com/gofiber/fiber/v2 v2.52.9/go.mod h1:YEcBbO/FB+5M1IZNBP9FO3J9281zgPAreiI1oqg8nDw=
 github.com/gofiber/fiber/v3 v3.0.0-rc.2 h1:5I3RQ7XygDBfWRlMhkATjyJKupMmfMAVmnsrgo6wmc0=
 github.com/gofiber/fiber/v3 v3.0.0-rc.2/go.mod h1:EHKwhVCONMruJTOmvSPSy0CdACJ3uqCY8vGaBXft8yg=
 github.com/gofiber/schema v1.6.0 h1:rAgVDFwhndtC+hgV7Vu5ItQCn7eC2mBA4Eu1/ZTiEYY=
@@ -82,8 +80,6 @@ github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHP
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
-github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
-github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
@@ -114,8 +110,6 @@ github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzM
 github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
 github.com/redis/go-redis/v9 v9.12.0 h1:XlVPGlflh4nxfhsNXPA8Qp6EmEfTo0rp8oaBzPipXnU=
 github.com/redis/go-redis/v9 v9.12.0/go.mod h1:huWgSWd8mW6+m0VPhJjSSQ+d6Nh1VICQ6Q5lHuCH/Iw=
-github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
-github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=

--- a/pkg/coordinator/archive.go
+++ b/pkg/coordinator/archive.go
@@ -158,11 +158,4 @@ func (h *archiveHandler) processArchivedTask(queueName string, taskInfo *asynq.T
 	}
 }
 
-// noopHandler is a no-op implementation when archive handling is disabled
-type noopHandler struct{}
-
-func (n *noopHandler) Start(_ context.Context) error { return nil }
-func (n *noopHandler) Stop() error                   { return nil }
-
 var _ ArchiveHandler = (*archiveHandler)(nil)
-var _ ArchiveHandler = (*noopHandler)(nil)

--- a/pkg/models/dag.go
+++ b/pkg/models/dag.go
@@ -11,8 +11,6 @@ import (
 var (
 	// ErrNonExistentDependency is returned when a model depends on a non-existent model
 	ErrNonExistentDependency = errors.New("model depends on non-existent model")
-	// ErrInconsistentGraph is returned when the dependency graph is inconsistent
-	ErrInconsistentGraph = errors.New("dependency graph is inconsistent: vertex count mismatch")
 	// ErrNotExternalModel is returned when a model is not an external model
 	ErrNotExternalModel = errors.New("model is not an external model")
 	// ErrNotTransformationModel is returned when a model is not a transformation model

--- a/pkg/models/transformation/dependency.go
+++ b/pkg/models/transformation/dependency.go
@@ -61,14 +61,6 @@ func (d *Dependency) UnmarshalYAML(node *yaml.Node) error {
 	}
 }
 
-// MarshalYAML implements custom YAML marshaling for mixed dependency types
-func (d Dependency) MarshalYAML() (interface{}, error) {
-	if d.IsGroup {
-		return d.GroupDeps, nil
-	}
-	return d.SingleDep, nil
-}
-
 // GetAllDependencies returns all dependency IDs from this dependency (flattened)
 func (d *Dependency) GetAllDependencies() []string {
 	if d.IsGroup {

--- a/pkg/models/transformation/incremental/incremental.go
+++ b/pkg/models/transformation/incremental/incremental.go
@@ -144,6 +144,11 @@ func (h *Handler) GetFlattenedDependencies() []string {
 	return result
 }
 
+// GetOriginalDependencies returns the original dependencies before placeholder substitution
+func (h *Handler) GetOriginalDependencies() []transformation.Dependency {
+	return h.config.OriginalDependencies
+}
+
 // SubstituteDependencyPlaceholders replaces {{external}} and {{transformation}} placeholders
 func (h *Handler) SubstituteDependencyPlaceholders(externalDefaultDB, transformationDefaultDB string) {
 	// Deep copy original dependencies before substitution


### PR DESCRIPTION
Replace integration tests requiring real Redis with unit tests using miniredis. Improves test reliability and removes external dependencies.

Changes:
- Add miniredis to scheduler ticker tests with thread-safe mocks
- Add miniredis to coordinator service tests for Process methods
- Fix template engine to preserve dependency placeholder mappings
- Remove unused noopHandler and MarshalYAML implementations
- Remove unused Fiber v2 dependency, migrate to v3
- Remove unused dependency graph error