### PR TITLE
fix(admin): delete consolidated rows by explicit key to stop clipping tail-model coverage

### DIFF
--- a/pkg/admin/service.go
+++ b/pkg/admin/service.go
@@ -20,6 +20,14 @@ var (
 	ErrCacheManagerUnavailable = errors.New("cache manager not available")
 )
 
+// consolidationDeleteBatchSize bounds how many (position, interval) keys go into a
+// single DELETE ... IN (...) statement. Large enough that a normal island is one
+// batch — in cluster mode each batch is a distributed DDL on the shared task queue,
+// so fewer is better — yet small enough that the rendered query stays well under
+// ClickHouse's max_query_size even for a long-overdue island of thousands of rows.
+// Each batch is still keyed, preserving the out-of-order-delete safety.
+const consolidationDeleteBatchSize = 5000
+
 // buildTableRef creates a backtick-escaped table reference for SQL queries.
 func buildTableRef(database, table string) string {
 	return fmt.Sprintf("`%s`.`%s`", database, table)
@@ -538,62 +546,131 @@ func (a *service) ConsolidateHistoricalData(ctx context.Context, modelID string)
 		"interval":  rangeResult.EndPos - rangeResult.StartPos,
 	}).Debug("Consolidating admin table rows")
 
-	// Capture timestamp for the consolidated row before insertion
-	// This allows us to delete all older rows using timestamp comparison
-	consolidationTime := time.Now().UTC()
-	consolidatedInterval := rangeResult.EndPos - rangeResult.StartPos
+	// Fetch the exact granular rows that make up this island BEFORE inserting the
+	// consolidated row. We delete precisely these keys afterwards — never a range —
+	// so a delete can only ever reference rows that existed at scan time. This is
+	// what makes consolidation safe against late or out-of-order deletes: an older
+	// delete can never clip a consolidated row written by a later run, because that
+	// newer row's (position, interval) was never in any earlier delete's key set.
+	membersQuery := fmt.Sprintf(`
+		SELECT position, interval
+		FROM %s FINAL
+		WHERE database = '%s' AND table = '%s'
+		  AND position >= %d AND position < %d
+	`, buildTableRef(a.adminDatabase, a.adminTable), database, table,
+		rangeResult.StartPos, rangeResult.EndPos)
 
-	// Insert the consolidated row FIRST to avoid gaps
-	// Use explicit timestamp to ensure we can reliably delete older rows
+	var members []ProcessedRange
+	if err := a.client.QueryMany(ctx, membersQuery, &members); err != nil {
+		return 0, fmt.Errorf("failed to fetch island members for consolidation: %w", err)
+	}
+
+	// Guard against the island shrinking between the range scan and this fetch
+	// (e.g. a concurrent delete). Nothing meaningful to merge if fewer than 2 rows.
+	if len(members) < 2 {
+		return 0, nil
+	}
+
+	// Derive the consolidated span from the rows we actually read, so the consolidated
+	// row always covers exactly the rows we are about to delete — even if the range
+	// scan observed a slightly different (e.g. partial) view of the island.
+	startPos := members[0].Position
+
+	var endPos uint64
+
+	for _, m := range members {
+		if m.Position < startPos {
+			startPos = m.Position
+		}
+
+		if end := m.Position + m.Interval; end > endPos {
+			endPos = end
+		}
+	}
+
+	consolidatedInterval := endPos - startPos
+
+	// Insert the consolidated row FIRST so coverage is never lost if the delete fails.
+	consolidationTime := time.Now().UTC()
 	insertQuery := fmt.Sprintf(`
 		INSERT INTO `+"`%s`.`%s`"+` (updated_date_time, database, table, position, interval)
 		VALUES ('%s', '%s', '%s', %d, %d)
 	`, a.adminDatabase, a.adminTable, consolidationTime.Format("2006-01-02 15:04:05.000"),
-		database, table, rangeResult.StartPos, consolidatedInterval)
+		database, table, startPos, consolidatedInterval)
 
 	if err := a.client.Execute(ctx, insertQuery); err != nil {
 		return 0, fmt.Errorf("failed to insert consolidated row: %w", err)
 	}
 
-	// Delete old rows using interval-based exclusion
-	// This is more robust than timestamp-based deletion because:
-	// 1. No dependency on clock precision or synchronization across cluster nodes
-	// 2. Explicitly excludes the consolidated row by its unique characteristic (larger interval)
-	// 3. Works reliably regardless of ReplacingMergeTree merge timing
-	// 4. Semantically clear: "delete all rows in range except the consolidated one"
-	//
-	// The consolidated row has interval = (end_pos - start_pos), which is larger than
-	// any individual row's interval in the consolidated range
-	var deleteQuery string
-	if a.cluster != "" {
-		// Cluster mode: use local suffix and ON CLUSTER
-		deleteQuery = fmt.Sprintf(`
-			DELETE FROM `+"`%s`.`%s%s`"+` ON CLUSTER '%s'
-			WHERE database = '%s' AND table = '%s'
-			  AND position >= %d AND position < %d
-			  AND interval != %d
-		`, a.adminDatabase, a.adminTable, a.localSuffix, a.cluster,
-			database, table, rangeResult.StartPos, rangeResult.EndPos,
-			consolidatedInterval)
-	} else {
-		// Non-cluster mode: simple DELETE
-		deleteQuery = fmt.Sprintf(`
+	// Delete the granular rows by their exact (position, interval) keys, excluding the
+	// consolidated row's own key (in case a member already matched it). Deleting by
+	// explicit identity — rather than "everything in range except this interval" —
+	// is what prevents a stale or out-of-order delete from clipping a newer
+	// consolidated row.
+	tuples := make([]string, 0, len(members))
+
+	for _, m := range members {
+		if m.Position == startPos && m.Interval == consolidatedInterval {
+			continue
+		}
+
+		tuples = append(tuples, fmt.Sprintf("(%d, %d)", m.Position, m.Interval))
+	}
+
+	// Unreachable when the member fetch uses FINAL: dedup guarantees at most one row
+	// can match the consolidated key, so len(tuples) >= len(members)-1 >= 1 past the
+	// "< 2" guard above. Kept as a guard in case the fetch ever becomes non-FINAL.
+	if len(tuples) == 0 {
+		return uint64(len(members)), nil
+	}
+
+	// buildDelete renders a keyed DELETE for one batch of (position, interval) pairs.
+	// Cluster mode targets the local replicated table ON CLUSTER so the delete reaches
+	// whichever shard holds this model's rows.
+	buildDelete := func(keyList string) string {
+		if a.cluster != "" {
+			return fmt.Sprintf(`
+				DELETE FROM `+"`%s`.`%s%s`"+` ON CLUSTER '%s'
+				WHERE database = '%s' AND table = '%s'
+				  AND (position, interval) IN (%s)
+			`, a.adminDatabase, a.adminTable, a.localSuffix, a.cluster,
+				database, table, keyList)
+		}
+
+		return fmt.Sprintf(`
 			DELETE FROM `+"`%s`.`%s`"+`
 			WHERE database = '%s' AND table = '%s'
-			  AND position >= %d AND position < %d
-			  AND interval != %d
+			  AND (position, interval) IN (%s)
 		`, a.adminDatabase, a.adminTable,
-			database, table, rangeResult.StartPos, rangeResult.EndPos,
-			consolidatedInterval)
+			database, table, keyList)
 	}
 
-	if err := a.client.Execute(ctx, deleteQuery); err != nil {
-		// Log error but don't fail - the consolidated row will eventually replace the old ones
-		// due to ReplacingMergeTree behavior
-		return rangeResult.RowCount, fmt.Errorf("consolidated row inserted but failed to delete old rows: %w", err)
+	// Delete in batches so a long-overdue island never produces a single IN-list
+	// that exceeds max_query_size. Each batch is still keyed, so the out-of-order
+	// delete safety holds per batch.
+	batches := (len(tuples) + consolidationDeleteBatchSize - 1) / consolidationDeleteBatchSize
+	if batches > 1 {
+		a.log.WithFields(logrus.Fields{
+			"model_id": modelID,
+			"rows":     len(tuples),
+			"batches":  batches,
+		}).Info("Consolidating large island across batched deletes")
 	}
 
-	return rangeResult.RowCount, nil
+	for start := 0; start < len(tuples); start += consolidationDeleteBatchSize {
+		end := start + consolidationDeleteBatchSize
+		if end > len(tuples) {
+			end = len(tuples)
+		}
+
+		if err := a.client.Execute(ctx, buildDelete(strings.Join(tuples[start:end], ", "))); err != nil {
+			// The consolidated row is already in place; any rows not yet removed are
+			// harmless over-coverage that the next run will clean up.
+			return uint64(len(members)), fmt.Errorf("consolidated row inserted but failed to delete old rows: %w", err)
+		}
+	}
+
+	return uint64(len(members)), nil
 }
 
 // DeletePeriod removes tracking rows that overlap [startPos, endPos) and re-inserts

--- a/pkg/admin/service_test.go
+++ b/pkg/admin/service_test.go
@@ -691,9 +691,7 @@ func TestConsolidateHistoricalDataQueryStructure(t *testing.T) {
 			expectedInDelete: []string{
 				"DELETE FROM",
 				"WHERE database = 'mydb' AND table = 'mytable'",
-				"AND position >=",
-				"AND position <",
-				"AND interval !=",
+				"(position, interval) IN (",
 			},
 			useCluster:  false,
 			clusterName: "",
@@ -711,7 +709,7 @@ func TestConsolidateHistoricalDataQueryStructure(t *testing.T) {
 				"DELETE FROM",
 				"ON CLUSTER 'test_cluster'",
 				"WHERE database = 'mydb' AND table = 'mytable'",
-				"AND interval !=",
+				"(position, interval) IN (",
 			},
 			useCluster:  true,
 			clusterName: "test_cluster",
@@ -745,12 +743,13 @@ func TestConsolidateHistoricalDataQueryStructure(t *testing.T) {
 			_, err := svc.ConsolidateHistoricalData(ctx, tt.modelID)
 			require.NoError(t, err)
 
-			// Should have 3 queries: SELECT (range query), INSERT (consolidated row), DELETE (rows in range)
-			require.Len(t, mockClient.queries, 3, "Expected 3 queries: SELECT, INSERT, DELETE")
+			// Should have 4 queries: SELECT (range scan), SELECT (island members),
+			// INSERT (consolidated row), DELETE (members by key)
+			require.Len(t, mockClient.queries, 4, "Expected 4 queries: SELECT range, SELECT members, INSERT, DELETE")
 
 			consolidationQuery := mockClient.queries[0]
-			insertQuery := mockClient.queries[1]
-			deleteQuery := mockClient.queries[2]
+			insertQuery := mockClient.queries[2]
+			deleteQuery := mockClient.queries[3]
 
 			// Verify consolidation query structure (should be 3-CTE)
 			for _, expected := range tt.expectedInQuery {
@@ -776,9 +775,11 @@ func TestConsolidateHistoricalDataQueryStructure(t *testing.T) {
 					"DELETE query should contain: %s", expected)
 			}
 
-			// Verify interval-based deletion strategy
-			assert.Contains(t, deleteQuery, "AND interval !=",
-				"DELETE should use interval-based exclusion")
+			// Verify explicit-key deletion strategy (safe against out-of-order deletes)
+			assert.Contains(t, deleteQuery, "(position, interval) IN (",
+				"DELETE should delete by explicit (position, interval) keys")
+			assert.NotContains(t, deleteQuery, "interval !=",
+				"DELETE should NOT use interval-based exclusion (clips newer consolidated rows)")
 			assert.NotContains(t, deleteQuery, "updated_date_time <",
 				"DELETE should NOT use timestamp-based deletion")
 		})
@@ -807,13 +808,88 @@ func TestConsolidateHistoricalDataClusterMode(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check DELETE query uses cluster syntax
-	require.Len(t, mockClient.queries, 3)
-	deleteQuery := mockClient.queries[2]
+	require.Len(t, mockClient.queries, 4)
+	deleteQuery := mockClient.queries[3]
 
 	assert.Contains(t, deleteQuery, "ON CLUSTER 'my_cluster'",
 		"DELETE in cluster mode should use ON CLUSTER")
 	assert.Contains(t, deleteQuery, "`admin`.`cbt_incremental_local`",
 		"DELETE in cluster mode should use local suffix")
+}
+
+// TestConsolidateHistoricalDataExcludesConsolidatedKey verifies the DELETE never
+// names the consolidated row's own (position, interval) key. This is the property
+// that stops a stale or out-of-order delete from clipping a newer consolidated row.
+func TestConsolidateHistoricalDataExcludesConsolidatedKey(t *testing.T) {
+	mockClient := &queryCapturingClient{
+		// Island members include a row whose key already equals the consolidated
+		// row's key (start=1000, span=1000); it must be kept, the rest deleted.
+		consolidationMembers: []ProcessedRange{
+			{Position: 1000, Interval: 1000}, // == consolidated key -> must NOT be deleted
+			{Position: 1000, Interval: 500},  // granular -> must be deleted
+			{Position: 1500, Interval: 500},  // granular -> must be deleted
+		},
+	}
+
+	log := logrus.New()
+	log.SetLevel(logrus.WarnLevel)
+	config := TableConfig{
+		IncrementalDatabase: "admin",
+		IncrementalTable:    "cbt_incremental",
+		ScheduledDatabase:   "admin",
+		ScheduledTable:      "cbt_scheduled",
+	}
+
+	svc := NewService(log, mockClient, "", "", config, nil)
+
+	_, err := svc.ConsolidateHistoricalData(context.Background(), "mydb.mytable")
+	require.NoError(t, err)
+
+	require.Len(t, mockClient.queries, 4)
+	deleteQuery := mockClient.queries[3]
+
+	assert.Contains(t, deleteQuery, "(1000, 500)", "granular row must be deleted")
+	assert.Contains(t, deleteQuery, "(1500, 500)", "granular row must be deleted")
+	assert.NotContains(t, deleteQuery, "(1000, 1000)",
+		"the consolidated row's own key must be excluded from the delete")
+}
+
+// TestConsolidateHistoricalDataChunksLargeDelete verifies a very large island is
+// removed across multiple batched DELETEs rather than one oversized IN-list that
+// could exceed ClickHouse's max_query_size.
+func TestConsolidateHistoricalDataChunksLargeDelete(t *testing.T) {
+	n := consolidationDeleteBatchSize + 1 // one past a single batch -> forces 2 batches
+
+	members := make([]ProcessedRange, 0, n)
+	for i := 0; i < n; i++ {
+		members = append(members, ProcessedRange{Position: uint64(i) * 10, Interval: 10})
+	}
+
+	mockClient := &queryCapturingClient{consolidationMembers: members}
+
+	log := logrus.New()
+	log.SetLevel(logrus.WarnLevel)
+	config := TableConfig{
+		IncrementalDatabase: "admin",
+		IncrementalTable:    "cbt_incremental",
+		ScheduledDatabase:   "admin",
+		ScheduledTable:      "cbt_scheduled",
+	}
+
+	svc := NewService(log, mockClient, "", "", config, nil)
+
+	_, err := svc.ConsolidateHistoricalData(context.Background(), "mydb.mytable")
+	require.NoError(t, err)
+
+	deletes := 0
+
+	for _, q := range mockClient.queries {
+		if strings.Contains(q, "DELETE FROM") {
+			deletes++
+		}
+	}
+
+	assert.Equal(t, 2, deletes, "large island should be deleted across 2 batches")
 }
 
 // consolidationMockClient is a specialized mock for consolidation testing
@@ -856,8 +932,29 @@ func (m *consolidationMockClient) QueryOne(_ context.Context, query string, resu
 	return nil
 }
 
-func (m *consolidationMockClient) QueryMany(_ context.Context, query string, _ any) error {
+func (m *consolidationMockClient) QueryMany(_ context.Context, query string, result any) error {
 	m.queries = append(m.queries, query)
+
+	rows, ok := result.(*[]ProcessedRange)
+	if !ok || m.rangeRowCount == 0 {
+		return nil
+	}
+
+	// Synthesize evenly-spaced island members spanning [start, end) so the
+	// consolidation flow has concrete rows to delete by key.
+	span := m.rangeEndPos - m.rangeStartPos
+	step := span / m.rangeRowCount
+
+	members := make([]ProcessedRange, 0, m.rangeRowCount)
+	for i := uint64(0); i < m.rangeRowCount; i++ {
+		members = append(members, ProcessedRange{
+			Position: m.rangeStartPos + i*step,
+			Interval: step,
+		})
+	}
+
+	*rows = members
+
 	return nil
 }
 
@@ -1017,9 +1114,10 @@ func TestHyphenatedDatabaseNamesInQueries(t *testing.T) {
 
 // queryCapturingClient is a mock ClickHouse client that captures queries for inspection
 type queryCapturingClient struct {
-	queries     []string
-	mockResults []any
-	resultIndex int
+	queries              []string
+	mockResults          []any
+	resultIndex          int
+	consolidationMembers []ProcessedRange
 }
 
 func (m *queryCapturingClient) Execute(_ context.Context, query string) error {
@@ -1066,6 +1164,20 @@ func (m *queryCapturingClient) QueryOne(_ context.Context, query string, result 
 
 func (m *queryCapturingClient) QueryMany(_ context.Context, query string, result any) error {
 	m.queries = append(m.queries, query)
+
+	// Consolidation island-member fetch.
+	if rows, ok := result.(*[]ProcessedRange); ok {
+		if m.consolidationMembers != nil {
+			*rows = m.consolidationMembers
+		} else {
+			*rows = []ProcessedRange{
+				{Position: 1000, Interval: 500},
+				{Position: 1500, Interval: 500},
+			}
+		}
+
+		return nil
+	}
 
 	if m.resultIndex < len(m.mockResults) {
 		// Return the mock result based on the actual type expected


### PR DESCRIPTION
## Problem

`ConsolidateHistoricalData` merges contiguous admin-table rows into one consolidated row, then deletes the originals. The delete used a **range predicate with an interval-based spare**:

```sql
DELETE ... WHERE position >= start AND position < end AND interval != consolidatedInterval
```

The spare key (`interval`) is **not stable across runs**. A tail (forward-fill-only) model re-consolidates the *same* `start` position every cycle with a *growing* interval:

```
run N   -> consolidated (start, I_N)
run N+1 -> consolidated (start, I_{N+1})   I_{N+1} > I_N
```

If `delete_N` (which spares `I_N`) runs **after** `run N+1` inserted `(start, I_{N+1})`, it deletes that newer consolidated row too — `I_{N+1} != I_N`, same `position`, inside `[start, end)`. The granular rows are already gone, so the model's early coverage silently disappears. Forward-fill only tracks the leading edge and has no backfill, so it never repaints it -> "missing rows".

### How it triggered in production

A rolling cluster restart brought a rebuilt replica back **missing part of its schema**, which jammed the shared distributed DDL queue (`/task_queue/ddl`). Consolidation's `DELETE ... ON CLUSTER` mutations are distributed DDLs, so they **timed out and executed late / out of order for ~20h**, exposing the clip. In steady state the deletes run promptly and in order, which is why this was rare and hard to pin down.

## Fix

Delete by the **exact `(position, interval)` keys** read in the island scan, excluding the consolidated row's own key:

```sql
DELETE ... WHERE database = ? AND table = ? AND (position, interval) IN ((p1,i1), (p2,i2), ...)
```

A delete can now only ever name rows that **existed at scan time**, so it can never reference a consolidated row written by a later run — independent of delete timing or ordering, and with **no clock dependency**. Specifically:

- Island members are fetched (`SELECT ... FINAL`) before the insert; the consolidated span is derived from the rows actually read, so the consolidated row always covers exactly what is deleted, even on a partial read.
- The consolidated row's own key is excluded from the delete set.
- Deletes are **batched (5000 keys/statement)** so a long-overdue island can't produce an `IN`-list that exceeds `max_query_size`; each batch stays keyed and ordering-safe.

## Tests

- Updated `TestConsolidateHistoricalDataQueryStructure` / `…ClusterMode` for the new `scan -> member-fetch -> insert -> keyed-delete` flow and the `(position, interval) IN (…)` predicate.
- Added `TestConsolidateHistoricalDataExcludesConsolidatedKey` — proves the consolidated row's key is never named in the delete.
- Added `TestConsolidateHistoricalDataChunksLargeDelete` — proves a large island is removed across multiple batches.

`go build ./...`, `go test ./pkg/admin/ -race`, and `golangci-lint` all pass.

## Follow-up (not in this PR)

The consolidation delete still uses `ON CLUSTER`, so it rides the shared DDL queue (the coupling that amplified the incident). Decoupling it to a shard-local delete that replicates via the table log is the proper liveness fix; batching keeps the interim behavior bounded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
