### PR TITLE
fix(models): restore individual file path support in DiscoverPaths

### DIFF
--- a/pkg/models/discovery.go
+++ b/pkg/models/discovery.go
@@ -25,7 +25,9 @@ type ModelFile struct {
 	Content   []byte
 }
 
-// DiscoverPaths walks directories to find model files (.sql, .yaml, .yml)
+// DiscoverPaths finds model files (.sql, .yaml, .yml) at the given paths.
+// Each path may be a directory, which is walked recursively, or an individual
+// model file.
 func DiscoverPaths(directories []string) ([]*ModelFile, error) {
 	var models []*ModelFile
 
@@ -41,7 +43,52 @@ func DiscoverPaths(directories []string) ([]*ModelFile, error) {
 	return models, nil
 }
 
+// discoverFile loads a single model file, root-scoped to its parent directory
+// so the file itself cannot be a symlink escaping it.
+func discoverFile(path string) ([]*ModelFile, error) {
+	ext := strings.ToLower(filepath.Ext(path))
+	if ext != ExtSQL && ext != ExtYAML && ext != ExtYML {
+		return nil, nil
+	}
+
+	parent := filepath.Dir(path)
+
+	root, err := os.OpenRoot(parent)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+
+		return nil, err
+	}
+	defer func() { _ = root.Close() }()
+
+	content, err := readFileFromRoot(root, filepath.Base(path))
+	if err != nil {
+		return nil, err
+	}
+
+	return []*ModelFile{{
+		FilePath:  path,
+		Extension: ext,
+		Content:   content,
+	}}, nil
+}
+
 func discoverInDirectory(dir string) ([]*ModelFile, error) {
+	info, err := os.Stat(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	if !info.IsDir() {
+		return discoverFile(dir)
+	}
+
 	root, err := os.OpenRoot(dir)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/pkg/models/discovery_test.go
+++ b/pkg/models/discovery_test.go
@@ -1,0 +1,85 @@
+package models
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiscoverPathsDirectory(t *testing.T) {
+	dir := t.TempDir()
+
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "nested"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.sql"), []byte("select 1"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "nested", "b.yaml"), []byte("key: value"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ignored.txt"), []byte("nope"), 0o600))
+
+	models, err := DiscoverPaths([]string{dir})
+	require.NoError(t, err)
+	require.Len(t, models, 2)
+}
+
+// Individual model file paths must be supported alongside directories: callers
+// such as the xatu-cbt test harness configure models as explicit file paths,
+// which worked prior to the os.Root rework (filepath.Walk visits a file path
+// directly, while os.OpenRoot on a file fails with ENOTDIR).
+func TestDiscoverPathsIndividualFile(t *testing.T) {
+	dir := t.TempDir()
+
+	path := filepath.Join(dir, "model.sql")
+	require.NoError(t, os.WriteFile(path, []byte("select 1"), 0o600))
+
+	models, err := DiscoverPaths([]string{path})
+	require.NoError(t, err)
+	require.Len(t, models, 1)
+	assert.Equal(t, path, models[0].FilePath)
+	assert.Equal(t, ExtSQL, models[0].Extension)
+	assert.Equal(t, []byte("select 1"), models[0].Content)
+}
+
+func TestDiscoverPathsMixedFileAndDirectory(t *testing.T) {
+	dir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.sql"), []byte("select 1"), 0o600))
+
+	fileDir := t.TempDir()
+	path := filepath.Join(fileDir, "b.yml")
+	require.NoError(t, os.WriteFile(path, []byte("key: value"), 0o600))
+
+	models, err := DiscoverPaths([]string{dir, path})
+	require.NoError(t, err)
+	require.Len(t, models, 2)
+}
+
+func TestDiscoverPathsFileWithUnsupportedExtension(t *testing.T) {
+	dir := t.TempDir()
+
+	path := filepath.Join(dir, "notes.txt")
+	require.NoError(t, os.WriteFile(path, []byte("nope"), 0o600))
+
+	models, err := DiscoverPaths([]string{path})
+	require.NoError(t, err)
+	assert.Empty(t, models)
+}
+
+func TestDiscoverPathsMissingPath(t *testing.T) {
+	models, err := DiscoverPaths([]string{filepath.Join(t.TempDir(), "does-not-exist")})
+	require.NoError(t, err)
+	assert.Empty(t, models)
+}
+
+func TestDiscoverPathsFileSymlinkEscapingParentIsRejected(t *testing.T) {
+	outside := t.TempDir()
+	target := filepath.Join(outside, "secret.sql")
+	require.NoError(t, os.WriteFile(target, []byte("select 'secret'"), 0o600))
+
+	dir := t.TempDir()
+	link := filepath.Join(dir, "model.sql")
+	require.NoError(t, os.Symlink(target, link))
+
+	_, err := DiscoverPaths([]string{link})
+	require.Error(t, err)
+}


### PR DESCRIPTION
The os.Root rework of model discovery broke configs that list individual model files instead of directories: `os.OpenRoot` on a file path fails with ENOTDIR, so the engine exits fatally at startup (`failed to discover models: ... not a directory`). `filepath.Walk` previously visited file paths directly, and the xatu-cbt test harness configures every model as an explicit file path — so every xatu-cbt model test against cbt 0.1.5 fails, with the engine dying in under a second inside `docker run --rm` and the harness then waiting out its 10-minute transformation timeout with nothing to show.

This detects the file case via `Stat` and loads it root-scoped to its parent directory, preserving the symlink-escape hardening: a model file that is itself a symlink pointing outside its parent is still rejected (covered by a new test).

Verified against the xatu-cbt harness: `int_beacon_committee_head` fails 1/10 assertions (zero rows, model permanently pending) on stock 0.1.5 and passes 10/10 with this fix overlaid on the same image; 0.1.4 passes as the known-good control.